### PR TITLE
Abstraction of Original Game Files access

### DIFF
--- a/docs-source/content/waynet.rst
+++ b/docs-source/content/waynet.rst
@@ -31,6 +31,8 @@ references to all other Waypoints that can be reached directly from its
 location. If a Waypoint is in reach of another Waypoint, that means there is a
 *Path* between the two.
 
+The scripts actually only tell the target destination a character should go to,
+so some sort of algorithm to find the shortest path to it is needed.
 
 The Waynet-Components
 ---------------------
@@ -44,7 +46,7 @@ recursive search for the name you are looking for from the scenes root object.
 
 .. note::
 
-   If you are querying a Waypoint by name and you are not *completely* that the object you are
+   If you are querying a Waypoint by name and you are not *completely* sure that the object you are
    looking for is indeed a Waypoint, it's better to search the full scene.
 
 If you have a ``Waypoint``-component at hand, you can query the paths reachable from that Waypoint

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(REGothEngine
   scripting/ScriptVMInterface.cpp
   scripting/ScriptObjectMapping.cpp
   original-content/VirtualFileSystem.cpp
+  original-content/OriginalGameFiles.cpp
   world/internals/ConstructFromZEN.cpp
   world/GameWorld.cpp
   gui/skin_gothic.cpp

--- a/src/REGothEngine.cpp
+++ b/src/REGothEngine.cpp
@@ -18,25 +18,21 @@ REGothEngine::~REGothEngine()
   shutdown();
 }
 
-bs::Vector<bs::Path> REGothEngine::getVdfsPackagesToLoad()
-{
-  return gOriginalGameFiles().allVdfsPackages();
-}
-
 void REGothEngine::loadOriginalGamePackages(const bs::String& argv0, const bs::Path& gameDirectory)
 {
+  OriginalGameFiles files = OriginalGameFiles(gameDirectory);
+
   gVirtualFileSystem().setPathToEngineExecutable(argv0);
-  gOriginalGameFiles().setOriginalFilesRoot(gameDirectory);
 
   bs::gDebug().logDebug("[VDFS] Indexing packages: ");
 
-  for (auto p : getVdfsPackagesToLoad())
+  for (auto p : files.allVdfsPackages())
   {
     bs::gDebug().logDebug("[VDFS]  - " + p.getFilename());
     gVirtualFileSystem().loadPackage(p);
   }
 
-  gVirtualFileSystem().mountDirectory(gOriginalGameFiles().vdfsFileEntryPoint());
+  gVirtualFileSystem().mountDirectory(files.vdfsFileEntryPoint());
 }
 
 bool REGothEngine::hasFoundGameFiles()

--- a/src/REGothEngine.cpp
+++ b/src/REGothEngine.cpp
@@ -9,6 +9,7 @@
 #include <Resources/BsResourceManifest.h>
 #include <Resources/BsResources.h>
 #include <Scene/BsSceneObject.h>
+#include <original-content/OriginalGameFiles.hpp>
 
 using namespace REGoth;
 
@@ -17,48 +18,23 @@ REGothEngine::~REGothEngine()
   shutdown();
 }
 
-bs::Vector<bs::String> REGothEngine::getVdfsPackagesToLoad(const bs::Path& dataDirectory)
+bs::Vector<bs::Path> REGothEngine::getVdfsPackagesToLoad(const bs::Path& dataDirectory)
 {
-  bs::Vector<bs::Path> filePaths;
-  bs::Vector<bs::Path> dirPaths;
-
-  bs::FileSystem::getChildren(dataDirectory, filePaths, dirPaths);
-
-  bs::Vector<bs::String> packages;
-
-  for (auto& p : filePaths)
-  {
-    bs::String ext = p.getExtension();
-
-    bool caseSensitive = false;
-    if (bs::StringUtil::compare(ext, bs::String(".vdf"), caseSensitive) == 0)
-    {
-      packages.push_back(p.getFilename());
-    }
-  }
-
-  return packages;
+  return gOriginalGameFiles().allVdfsPackages();
 }
 
 void REGothEngine::loadOriginalGamePackages(const bs::String& argv0, const bs::Path& gameDirectory)
 {
   gVirtualFileSystem().setPathToEngineExecutable(argv0);
-  gVirtualFileSystem().setGameDirectory(gameDirectory);
+  gOriginalGameFiles().setOriginalFilesRoot(gameDirectory);
 
   bs::gDebug().logDebug("[VDFS] Indexing packages: ");
 
   // FIXME: Locate correct case of 'Data'-directory
   for (auto p : getVdfsPackagesToLoad(gameDirectory + "Data"))
   {
-    if (!gVirtualFileSystem().isPackageAvailable(p))
-    {
-      bs::gDebug().logDebug("[VDFS]  - " + bs::String(p) + " (not found)");
-    }
-    else
-    {
-      bs::gDebug().logDebug("[VDFS]  - " + bs::String(p));
-      gVirtualFileSystem().loadPackage(p);
-    }
+    bs::gDebug().logDebug("[VDFS]  - " + p.getFilename());
+    gVirtualFileSystem().loadPackage(p);
   }
 }
 

--- a/src/REGothEngine.cpp
+++ b/src/REGothEngine.cpp
@@ -18,7 +18,7 @@ REGothEngine::~REGothEngine()
   shutdown();
 }
 
-bs::Vector<bs::Path> REGothEngine::getVdfsPackagesToLoad(const bs::Path& dataDirectory)
+bs::Vector<bs::Path> REGothEngine::getVdfsPackagesToLoad()
 {
   return gOriginalGameFiles().allVdfsPackages();
 }
@@ -30,8 +30,7 @@ void REGothEngine::loadOriginalGamePackages(const bs::String& argv0, const bs::P
 
   bs::gDebug().logDebug("[VDFS] Indexing packages: ");
 
-  // FIXME: Locate correct case of 'Data'-directory
-  for (auto p : getVdfsPackagesToLoad(gameDirectory + "Data"))
+  for (auto p : getVdfsPackagesToLoad())
   {
     bs::gDebug().logDebug("[VDFS]  - " + p.getFilename());
     gVirtualFileSystem().loadPackage(p);

--- a/src/REGothEngine.cpp
+++ b/src/REGothEngine.cpp
@@ -35,6 +35,8 @@ void REGothEngine::loadOriginalGamePackages(const bs::String& argv0, const bs::P
     bs::gDebug().logDebug("[VDFS]  - " + p.getFilename());
     gVirtualFileSystem().loadPackage(p);
   }
+
+  gVirtualFileSystem().mountDirectory(gOriginalGameFiles().vdfsFileEntryPoint());
 }
 
 bool REGothEngine::hasFoundGameFiles()

--- a/src/REGothEngine.hpp
+++ b/src/REGothEngine.hpp
@@ -42,7 +42,7 @@ namespace REGoth
      * are).
      * @return List of VDFS-Packages to be loaded by the engine
      */
-    virtual bs::Vector<bs::Path> getVdfsPackagesToLoad(const bs::Path& dataDirectory);
+    virtual bs::Vector<bs::Path> getVdfsPackagesToLoad();
 
     /**
      * Load VDFS packages from the original game.

--- a/src/REGothEngine.hpp
+++ b/src/REGothEngine.hpp
@@ -7,8 +7,6 @@
 
 namespace REGoth
 {
-  class OriginalGameFiles;
-
   /**
    * This is the REGoth-Core-Class, which initializes the engine, sets the
    * input and the scene.

--- a/src/REGothEngine.hpp
+++ b/src/REGothEngine.hpp
@@ -42,7 +42,7 @@ namespace REGoth
      * are).
      * @return List of VDFS-Packages to be loaded by the engine
      */
-    virtual bs::Vector<bs::String> getVdfsPackagesToLoad(const bs::Path& dataDirectory);
+    virtual bs::Vector<bs::Path> getVdfsPackagesToLoad(const bs::Path& dataDirectory);
 
     /**
      * Load VDFS packages from the original game.

--- a/src/REGothEngine.hpp
+++ b/src/REGothEngine.hpp
@@ -7,6 +7,8 @@
 
 namespace REGoth
 {
+  class OriginalGameFiles;
+
   /**
    * This is the REGoth-Core-Class, which initializes the engine, sets the
    * input and the scene.
@@ -32,17 +34,6 @@ namespace REGoth
   public:
     REGothEngine() = default;
     virtual ~REGothEngine();
-
-    /**
-     * Construct a list of VDFS-packages to load here.
-     *
-     * By default, all packages within the games Data-Directory are loaded.
-     *
-     * @param  dataDirectory  Path of the Data-Directory of the game files (Where the .VDF-files
-     * are).
-     * @return List of VDFS-Packages to be loaded by the engine
-     */
-    virtual bs::Vector<bs::Path> getVdfsPackagesToLoad();
 
     /**
      * Load VDFS packages from the original game.

--- a/src/main_CharacterMovementTest.cpp
+++ b/src/main_CharacterMovementTest.cpp
@@ -1,6 +1,5 @@
 #include "BsFPSCamera.h"
 #include "REGothEngine.hpp"
-#include <original-content/OriginalGameFiles.hpp>
 #include <BsZenLib/ImportTexture.hpp>
 #include <Components/BsCCamera.h>
 #include <Components/BsCPlaneCollider.h>
@@ -38,8 +37,7 @@ public:
   {
     using namespace REGoth;
 
-    Daedalus::DATFile dat(REGoth::gOriginalGameFiles().gothicDat().toString().c_str());
-    Scripting::loadGothicDAT(dat);
+    Scripting::loadGothicDAT(gVirtualFileSystem().readFile("GOTHIC.DAT"));
 
     // World::loadWorldFromZEN("ADDONWORLD.ZEN", World::GameWorld::Init::NoInitScripts);
     World::loadWorldEmpty();

--- a/src/main_CharacterMovementTest.cpp
+++ b/src/main_CharacterMovementTest.cpp
@@ -1,5 +1,6 @@
 #include "BsFPSCamera.h"
 #include "REGothEngine.hpp"
+#include <original-content/OriginalGameFiles.hpp>
 #include <BsZenLib/ImportTexture.hpp>
 #include <Components/BsCCamera.h>
 #include <Components/BsCPlaneCollider.h>
@@ -37,7 +38,7 @@ public:
   {
     using namespace REGoth;
 
-    Daedalus::DATFile dat("/home/andre/games/Gothic II/_work/Data/Scripts/_compiled/GOTHIC.DAT");
+    Daedalus::DATFile dat(REGoth::gOriginalGameFiles().gothicDat().toString().c_str());
     Scripting::loadGothicDAT(dat);
 
     // World::loadWorldFromZEN("ADDONWORLD.ZEN", World::GameWorld::Init::NoInitScripts);

--- a/src/main_CharacterViewer.cpp
+++ b/src/main_CharacterViewer.cpp
@@ -23,6 +23,7 @@
 #include <components/Waynet.hpp>
 #include <components/Waypoint.hpp>
 #include <daedalus/DATFile.h>
+#include <original-content/OriginalGameFiles.hpp>
 #include <scripting/ScriptVMInterface.hpp>
 #include <world/GameWorld.hpp>
 
@@ -154,7 +155,7 @@ public:
       gDebug().logDebug(s);
     }
 
-    Daedalus::DATFile dat("/home/andre/games/Gothic II/_work/Data/Scripts/_compiled/GOTHIC.DAT");
+    Daedalus::DATFile dat(REGoth::gOriginalGameFiles().gothicDat().toString().c_str());
     REGoth::Scripting::loadGothicDAT(dat);
 
     REGoth::World::loadWorldEmpty();
@@ -183,7 +184,7 @@ public:
 
     Sphere bounds = playerVisual->getBounds().getSphere();
 
-    Vector3 cameraDirection = Vector3(1,0,0);
+    Vector3 cameraDirection = Vector3(1, 0, 0);
     cameraDirection.normalize();
 
     auto cameraOffset = cameraDirection * bounds.getRadius() * 1.7f;

--- a/src/main_CharacterViewer.cpp
+++ b/src/main_CharacterViewer.cpp
@@ -23,7 +23,7 @@
 #include <components/Waynet.hpp>
 #include <components/Waypoint.hpp>
 #include <daedalus/DATFile.h>
-#include <original-content/OriginalGameFiles.hpp>
+#include <original-content/VirtualFileSystem.hpp>
 #include <scripting/ScriptVMInterface.hpp>
 #include <world/GameWorld.hpp>
 
@@ -149,32 +149,32 @@ public:
   void setupScene() override
   {
     using namespace bs;
+    using namespace REGoth;
 
-    for (auto s : REGoth::gVirtualFileSystem().listAllFiles())
+    for (auto s : gVirtualFileSystem().listAllFiles())
     {
       gDebug().logDebug(s);
     }
 
-    Daedalus::DATFile dat(REGoth::gOriginalGameFiles().gothicDat().toString().c_str());
-    REGoth::Scripting::loadGothicDAT(dat);
+    Scripting::loadGothicDAT(gVirtualFileSystem().readFile("GOTHIC.DAT"));
 
-    REGoth::World::loadWorldEmpty();
+    World::loadWorldEmpty();
 
     // Add some waypoint
     bs::String wpName = "SOMEPLACE";
     {
       bs::HSceneObject wpSO = bs::SceneObject::create(wpName);
 
-      wpSO->setParent(REGoth::gWorld().waynet()->SO());
+      wpSO->setParent(gWorld().waynet()->SO());
       wpSO->setPosition(bs::Vector3(0, 0, 0));
 
-      REGoth::HWaypoint wp = wpSO->addComponent<REGoth::Waypoint>();
-      REGoth::gWorld().waynet()->addWaypoint(wp);
+      HWaypoint wp = wpSO->addComponent<Waypoint>();
+      gWorld().waynet()->addWaypoint(wp);
     }
 
-    REGoth::HCharacter character = REGoth::gWorld().insertCharacter("PC_HERO", wpName);
+    HCharacter character = gWorld().insertCharacter("PC_HERO", wpName);
 
-    REGoth::HVisualCharacter playerVisual = character->SO()->getComponent<REGoth::VisualCharacter>();
+    HVisualCharacter playerVisual = character->SO()->getComponent<VisualCharacter>();
     character->SO()->addComponent<SimpleCharacterController>(playerVisual);
     character->SO()->addComponent<bs::ObjectRotator>();
 

--- a/src/main_ScriptTest.cpp
+++ b/src/main_ScriptTest.cpp
@@ -3,6 +3,7 @@
 #include <Scene/BsSceneObject.h>
 #include <components/Item.hpp>
 #include <daedalus/DATFile.h>
+#include <original-content/OriginalGameFiles.hpp>
 #include <scripting/ScriptSymbolStorage.hpp>
 #include <scripting/ScriptVMInterface.hpp>
 
@@ -20,7 +21,7 @@ public:
     using ScriptObject       = Scripting::ScriptObject;
     using ScriptObjectHandle = Scripting::ScriptObjectHandle;
 
-    Daedalus::DATFile dat("/home/andre/games/Gothic II/_work/Data/Scripts/_compiled/GOTHIC.DAT");
+    Daedalus::DATFile dat(REGoth::gOriginalGameFiles().gothicDat().toString().c_str());
     REGoth::Scripting::loadGothicDAT(dat);
 
     // ScriptObjectHandle appleHandle = gGameScript().instanciateClass("C_ITEM", "ITFO_APPLE");

--- a/src/main_ScriptTest.cpp
+++ b/src/main_ScriptTest.cpp
@@ -3,7 +3,7 @@
 #include <Scene/BsSceneObject.h>
 #include <components/Item.hpp>
 #include <daedalus/DATFile.h>
-#include <original-content/OriginalGameFiles.hpp>
+#include <original-content/VirtualFileSystem.hpp>
 #include <scripting/ScriptSymbolStorage.hpp>
 #include <scripting/ScriptVMInterface.hpp>
 
@@ -21,8 +21,7 @@ public:
     using ScriptObject       = Scripting::ScriptObject;
     using ScriptObjectHandle = Scripting::ScriptObjectHandle;
 
-    Daedalus::DATFile dat(REGoth::gOriginalGameFiles().gothicDat().toString().c_str());
-    REGoth::Scripting::loadGothicDAT(dat);
+    Scripting::loadGothicDAT(gVirtualFileSystem().readFile("GOTHIC.DAT"));
 
     // ScriptObjectHandle appleHandle = gGameScript().instanciateClass("C_ITEM", "ITFO_APPLE");
 

--- a/src/main_WaynetTest.cpp
+++ b/src/main_WaynetTest.cpp
@@ -7,6 +7,7 @@
 #include <components/Waypoint.hpp>
 #include <daedalus/DATFile.h>
 #include <excepction/Throw.hpp>
+#include <original-content/OriginalGameFiles.hpp>
 #include <scripting/ScriptVMInterface.hpp>
 #include <world/GameWorld.hpp>
 
@@ -24,7 +25,7 @@ public:
   {
     using namespace REGoth;
 
-    Daedalus::DATFile dat("/home/andre/games/Gothic II/_work/Data/Scripts/_compiled/GOTHIC.DAT");
+    Daedalus::DATFile dat(REGoth::gOriginalGameFiles().gothicDat().toString().c_str());
     Scripting::loadGothicDAT(dat);
 
     World::loadWorldFromZEN("OLDWORLD.ZEN", World::GameWorld::Init::NoInitScripts);

--- a/src/main_WaynetTest.cpp
+++ b/src/main_WaynetTest.cpp
@@ -7,7 +7,7 @@
 #include <components/Waypoint.hpp>
 #include <daedalus/DATFile.h>
 #include <excepction/Throw.hpp>
-#include <original-content/OriginalGameFiles.hpp>
+#include <original-content/VirtualFileSystem.hpp>
 #include <scripting/ScriptVMInterface.hpp>
 #include <world/GameWorld.hpp>
 
@@ -25,8 +25,7 @@ public:
   {
     using namespace REGoth;
 
-    Daedalus::DATFile dat(REGoth::gOriginalGameFiles().gothicDat().toString().c_str());
-    Scripting::loadGothicDAT(dat);
+    Scripting::loadGothicDAT(gVirtualFileSystem().readFile("GOTHIC.DAT"));
 
     World::loadWorldFromZEN("OLDWORLD.ZEN", World::GameWorld::Init::NoInitScripts);
 

--- a/src/main_WorldViewer.cpp
+++ b/src/main_WorldViewer.cpp
@@ -3,7 +3,7 @@
 #include <Components/BsCCamera.h>
 #include <Scene/BsSceneObject.h>
 #include <daedalus/DATFile.h>
-#include <original-content/OriginalGameFiles.hpp>
+#include <original-content/VirtualFileSystem.hpp>
 #include <scripting/ScriptVMInterface.hpp>
 #include <world/GameWorld.hpp>
 
@@ -19,10 +19,11 @@ public:
 
   void setupScene() override
   {
-    Daedalus::DATFile dat(REGoth::gOriginalGameFiles().gothicDat().toString().c_str());
-    REGoth::Scripting::loadGothicDAT(dat);
+    using namespace REGoth;
 
-    REGoth::World::loadWorldFromZEN("ADDONWORLD.ZEN");
+    Scripting::loadGothicDAT(gVirtualFileSystem().readFile("GOTHIC.DAT"));
+
+    World::loadWorldFromZEN("ADDONWORLD.ZEN");
   }
 
 protected:

--- a/src/main_WorldViewer.cpp
+++ b/src/main_WorldViewer.cpp
@@ -3,6 +3,7 @@
 #include <Components/BsCCamera.h>
 #include <Scene/BsSceneObject.h>
 #include <daedalus/DATFile.h>
+#include <original-content/OriginalGameFiles.hpp>
 #include <scripting/ScriptVMInterface.hpp>
 #include <world/GameWorld.hpp>
 
@@ -18,7 +19,7 @@ public:
 
   void setupScene() override
   {
-    Daedalus::DATFile dat("/home/andre/games/Gothic II/_work/Data/Scripts/_compiled/GOTHIC.DAT");
+    Daedalus::DATFile dat(REGoth::gOriginalGameFiles().gothicDat().toString().c_str());
     REGoth::Scripting::loadGothicDAT(dat);
 
     REGoth::World::loadWorldFromZEN("ADDONWORLD.ZEN");

--- a/src/original-content/OriginalGameFiles.cpp
+++ b/src/original-content/OriginalGameFiles.cpp
@@ -4,14 +4,9 @@
 
 namespace REGoth
 {
-  void OriginalGameFiles::setOriginalFilesRoot(const bs::Path& root)
+  OriginalGameFiles::OriginalGameFiles(const bs::Path& root)
+    : mRoot(root)
   {
-    mRoot = root;
-
-    if (mRoot.getTail() == "")
-    {
-    }
-
     if (vdfsFileEntryPoint() == bs::Path::BLANK)
     {
       REGOTH_THROW(FileNotFoundException,
@@ -146,11 +141,5 @@ namespace REGoth
     }
 
     return matching;
-  }
-
-  OriginalGameFiles& gOriginalGameFiles()
-  {
-    static OriginalGameFiles s_Instance;
-    return s_Instance;
   }
 }  // namespace REGoth

--- a/src/original-content/OriginalGameFiles.cpp
+++ b/src/original-content/OriginalGameFiles.cpp
@@ -10,47 +10,62 @@ namespace REGoth
 
     if (mRoot.getTail() == "")
     {
-      
+    }
+
+    if (vdfsFileEntryPoint() == bs::Path::BLANK)
+    {
+      REGOTH_THROW(FileNotFoundException,
+                   bs::StringUtil::format(
+                       "Game-file directory {0} does not seem to have a '_work/data'-directory!",
+                       mRoot.toString()));
     }
 
     if (dataDirectory() == bs::Path::BLANK)
     {
-      REGOTH_THROW(FileNotFoundException,
-                   bs::StringUtil::format(
-                       "Game-file directory {0} does not seem to have a 'data'-directory!", mRoot.toString()));
+      REGOTH_THROW(
+          FileNotFoundException,
+          bs::StringUtil::format("Game-file directory {0} does not seem to have a 'data'-directory!",
+                                 mRoot.toString()));
     }
 
     if (gothicDat() == bs::Path::BLANK)
     {
-      REGOTH_THROW(FileNotFoundException,
-                   bs::StringUtil::format(
-                       "Game-file directory {0} does not seem to contain GOTHIC.DAT", mRoot.toString()));
+      REGOTH_THROW(
+          FileNotFoundException,
+          bs::StringUtil::format("Game-file directory {0} does not seem to contain GOTHIC.DAT",
+                                 mRoot.toString()));
     }
 
     if (allVdfsPackages().empty())
     {
-      REGOTH_THROW(FileNotFoundException,
-                   bs::StringUtil::format(
-                     "Game-file directory {0} does not seem to contain any .vdf-files!", mRoot.toString()));
+      REGOTH_THROW(
+          FileNotFoundException,
+          bs::StringUtil::format("Game-file directory {0} does not seem to contain any .vdf-files!",
+                                 mRoot.toString()));
     }
   }
 
-  bs::Path OriginalGameFiles::gothicDat()
+  bs::Path OriginalGameFiles::gothicDat() const
   {
     return findCaseSensitivePathOf("_work/Data/Scripts/_compiled/GOTHIC.DAT");
   }
 
-  bs::Path OriginalGameFiles::dataDirectory()
+  bs::Path OriginalGameFiles::dataDirectory() const
   {
     return findCaseSensitivePathOf("data/");
   }
 
-  bs::Vector<bs::Path> OriginalGameFiles::allVdfsPackages()
+  bs::Path OriginalGameFiles::vdfsFileEntryPoint() const
+  {
+    return findCaseSensitivePathOf("_work/data/");
+  }
+
+  bs::Vector<bs::Path> OriginalGameFiles::allVdfsPackages() const
   {
     return filterFilesInDirectoryByExt(dataDirectory(), ".vdf");
   }
 
-  bs::Path OriginalGameFiles::findCaseSensitivePathOf(const bs::Path& path)
+  bs::Path OriginalGameFiles::findCaseSensitivePathOf(const bs::Path& path) const
   {
     bs::Path actual = mRoot;
 
@@ -75,7 +90,7 @@ namespace REGoth
   }
 
   bs::Path OriginalGameFiles::appendCaseInsensitiveThing(const bs::Path& path,
-                                                         const bs::String& directory)
+                                                         const bs::String& directory) const
   {
     bs::Vector<bs::Path> files;
     bs::Vector<bs::Path> dirs;
@@ -108,7 +123,7 @@ namespace REGoth
   }
 
   bs::Vector<bs::Path> OriginalGameFiles::filterFilesInDirectoryByExt(const bs::Path& path,
-                                                                      const bs::String& ext)
+                                                                      const bs::String& ext) const
   {
     bs::Vector<bs::Path> files;
     bs::Vector<bs::Path> dirs;

--- a/src/original-content/OriginalGameFiles.cpp
+++ b/src/original-content/OriginalGameFiles.cpp
@@ -1,0 +1,141 @@
+#include "OriginalGameFiles.hpp"
+#include <FileSystem/BsFileSystem.h>
+#include <excepction/Throw.hpp>
+
+namespace REGoth
+{
+  void OriginalGameFiles::setOriginalFilesRoot(const bs::Path& root)
+  {
+    mRoot = root;
+
+    if (mRoot.getTail() == "")
+    {
+      
+    }
+
+    if (dataDirectory() == bs::Path::BLANK)
+    {
+      REGOTH_THROW(FileNotFoundException,
+                   bs::StringUtil::format(
+                       "Game-file directory {0} does not seem to have a 'data'-directory!", mRoot.toString()));
+    }
+
+    if (gothicDat() == bs::Path::BLANK)
+    {
+      REGOTH_THROW(FileNotFoundException,
+                   bs::StringUtil::format(
+                       "Game-file directory {0} does not seem to contain GOTHIC.DAT", mRoot.toString()));
+    }
+
+    if (allVdfsPackages().empty())
+    {
+      REGOTH_THROW(FileNotFoundException,
+                   bs::StringUtil::format(
+                     "Game-file directory {0} does not seem to contain any .vdf-files!", mRoot.toString()));
+    }
+  }
+
+  bs::Path OriginalGameFiles::gothicDat()
+  {
+    return findCaseSensitivePathOf("_work/Data/Scripts/_compiled/GOTHIC.DAT");
+  }
+
+  bs::Path OriginalGameFiles::dataDirectory()
+  {
+    return findCaseSensitivePathOf("data/");
+  }
+
+  bs::Vector<bs::Path> OriginalGameFiles::allVdfsPackages()
+  {
+    return filterFilesInDirectoryByExt(dataDirectory(), ".vdf");
+  }
+
+  bs::Path OriginalGameFiles::findCaseSensitivePathOf(const bs::Path& path)
+  {
+    bs::Path actual = mRoot;
+
+    for (bs::UINT32 i = 0; i < path.getNumDirectories(); i++)
+    {
+      actual = appendCaseInsensitiveThing(actual, path.getDirectory(i));
+
+      if (actual == bs::Path::BLANK)
+      {
+        return bs::Path::BLANK;
+      }
+    }
+
+    if (path.isFile())
+    {
+      return appendCaseInsensitiveThing(actual, path.getFilename());
+    }
+    else
+    {
+      return actual;
+    }
+  }
+
+  bs::Path OriginalGameFiles::appendCaseInsensitiveThing(const bs::Path& path,
+                                                         const bs::String& directory)
+  {
+    bs::Vector<bs::Path> files;
+    bs::Vector<bs::Path> dirs;
+
+    bs::FileSystem::getChildren(path, files, dirs);
+
+    enum
+    {
+      RespectCase = true,
+      IgnoreCase  = false,
+    };
+
+    for (const bs::Path& p : dirs)
+    {
+      if (bs::StringUtil::compare(p.getTail(), directory, IgnoreCase) == 0)
+      {
+        return p;
+      }
+    }
+
+    for (const bs::Path& p : files)
+    {
+      if (bs::StringUtil::compare(p.getTail(), directory, IgnoreCase) == 0)
+      {
+        return p;
+      }
+    }
+
+    return bs::Path::BLANK;
+  }
+
+  bs::Vector<bs::Path> OriginalGameFiles::filterFilesInDirectoryByExt(const bs::Path& path,
+                                                                      const bs::String& ext)
+  {
+    bs::Vector<bs::Path> files;
+    bs::Vector<bs::Path> dirs;
+
+    bs::FileSystem::getChildren(dataDirectory(), files, dirs);
+
+    enum
+    {
+      RespectCase = true,
+      IgnoreCase  = false,
+    };
+
+    bs::Vector<bs::Path> matching;
+    for (const bs::Path& p : files)
+    {
+      if (bs::StringUtil::compare(p.getExtension(), ext, IgnoreCase) == 0)
+      {
+        matching.push_back(p);
+      }
+    }
+
+    return matching;
+  }
+
+  OriginalGameFiles& gOriginalGameFiles()
+  {
+    static OriginalGameFiles s_Instance;
+    return s_Instance;
+  }
+}  // namespace REGoth

--- a/src/original-content/OriginalGameFiles.hpp
+++ b/src/original-content/OriginalGameFiles.hpp
@@ -1,0 +1,116 @@
+#pragma once
+#include <BsPrerequisites.h>
+#include <FileSystem/BsPath.h>
+
+namespace REGoth
+{
+  /**
+   * This class provides easy access to the original game files for all platforms.
+   *
+   * Since Gothic was developed on Windows-Systems, which uses a case-insensitive
+   * file system, there are major differences in file naming between releases.
+   * Sometimes a folder is called `Data`, `DATA` or `data`, you get the idea.
+   *
+   * This is troublesome for UNIX-systems which generally use case-sensitive
+   * file systems.
+   *
+   * Another reason this class exists is so we can abstract away the paths to
+   * certain files used by the engine.
+   *
+   * Generally, all paths you get back are in the correct case for your system.
+   */
+
+  class OriginalGameFiles
+  {
+  public:
+    OriginalGameFiles() = default;
+
+    /**
+     * Set where the original files can be found. This must be set
+     * before the other methods will return meaningful results.
+     *
+     * @param  root  Root of the original game file directory,
+     *               which contains `system`, `_work` and so on.
+     */
+    void setOriginalFilesRoot(const bs::Path& root);
+
+    /**
+     * @return List of all .vdf-packages found in the `Data`-directory.
+     */
+    bs::Vector<bs::Path> allVdfsPackages();
+
+    /**
+     * @return Actual path to the GOTHIC.DAT file
+     */
+    bs::Path gothicDat();
+
+  private:
+
+    /**
+     * Outputs all files found in the given directory which match the given extension.
+     *
+     * The comparison is done case-insensitive.
+     *
+     * @param  path  Path to the directory to search.
+     * @param  ext   Extension to search for (with .), e.g. `.vdf`
+     *
+     * @return List of all files in the given directory with the given extension.
+     */
+    bs::Vector<bs::Path> filterFilesInDirectoryByExt(const bs::Path& path, const bs::String& ext);
+
+    /**
+     * @return Actual path to the data-directory
+     */
+    bs::Path dataDirectory();
+
+    /**
+     * Given a case-insensitive path, this tries to find the real, case-sensitive path.
+     *
+     * Should there exist two files with the same name, it is undefined which one you get,
+     * so you should avoid that.
+     *
+     * If the file wasn't found, an empty path is returned.
+     *
+     * @param  path  Case-insensitive path to look at relative to the game root.
+     * @return First file that matched the case insensitive path.
+     */
+    bs::Path findCaseSensitivePathOf(const bs::Path& path);
+
+    /**
+     * Given a directory and the name of a directory or file, this will try to find
+     * the correct cased name in the file system and append it to the path.
+     *
+     * Throws if the given path already is a file.
+     * Returns an empty path if the thing didn't exist.
+     *
+     * @param  path  Absolute Path to append to. Should already be in the correct case.
+     * @param  thing Name of the directory or file to append.
+     *
+     * @return Input path with the given directory or file appended in the correct case.
+     *         bs::Path::BLANK if the given directory or file was not found.
+     */
+    bs::Path appendCaseInsensitiveThing(const bs::Path& path, const bs::String& thing);
+
+    /**
+     * Root of the original game directory
+     */
+    bs::Path mRoot;
+
+    /**
+     * Paths to all files stored inside the game directory
+     */
+    bs::Vector<bs::Path> mAllFiles;
+
+    /**
+     * Map which does case-insensitive path to index into mAllFiles,
+     * which stores the case-sensitive path.
+     */
+    bs::Map<bs::Path, bs::UINT32> mCaseMap;
+  };
+
+  /**
+   * Access to the original game files.
+   */
+  OriginalGameFiles& gOriginalGameFiles();
+
+}  // namespace REGoth

--- a/src/original-content/OriginalGameFiles.hpp
+++ b/src/original-content/OriginalGameFiles.hpp
@@ -23,16 +23,14 @@ namespace REGoth
   class OriginalGameFiles
   {
   public:
-    OriginalGameFiles() = default;
-
     /**
-     * Set where the original files can be found. This must be set
-     * before the other methods will return meaningful results.
+     * Construct a new OriginalGameFiles Object given the root path
+     * of the original game.
      *
      * @param  root  Root of the original game file directory,
      *               which contains `system`, `_work` and so on.
      */
-    void setOriginalFilesRoot(const bs::Path& root);
+    OriginalGameFiles(const bs::Path& root);
 
     /**
      * @return List of all .vdf-packages found in the `Data`-directory.
@@ -51,7 +49,6 @@ namespace REGoth
     bs::Path vdfsFileEntryPoint() const;
 
   private:
-
     /**
      * Outputs all files found in the given directory which match the given extension.
      *
@@ -62,7 +59,8 @@ namespace REGoth
      *
      * @return List of all files in the given directory with the given extension.
      */
-    bs::Vector<bs::Path> filterFilesInDirectoryByExt(const bs::Path& path, const bs::String& ext) const;
+    bs::Vector<bs::Path> filterFilesInDirectoryByExt(const bs::Path& path,
+                                                     const bs::String& ext) const;
 
     /**
      * @return Actual path to the data-directory
@@ -113,10 +111,5 @@ namespace REGoth
      */
     bs::Map<bs::Path, bs::UINT32> mCaseMap;
   };
-
-  /**
-   * Access to the original game files.
-   */
-  OriginalGameFiles& gOriginalGameFiles();
 
 }  // namespace REGoth

--- a/src/original-content/OriginalGameFiles.hpp
+++ b/src/original-content/OriginalGameFiles.hpp
@@ -37,12 +37,18 @@ namespace REGoth
     /**
      * @return List of all .vdf-packages found in the `Data`-directory.
      */
-    bs::Vector<bs::Path> allVdfsPackages();
+    bs::Vector<bs::Path> allVdfsPackages() const;
 
     /**
      * @return Actual path to the GOTHIC.DAT file
      */
-    bs::Path gothicDat();
+    bs::Path gothicDat() const;
+
+    /**
+     * @return Actual path the `_work/Data` directory where files outside
+     *         .vdf-packages are stored but should still accessible via VDFS.
+     */
+    bs::Path vdfsFileEntryPoint() const;
 
   private:
 
@@ -56,12 +62,12 @@ namespace REGoth
      *
      * @return List of all files in the given directory with the given extension.
      */
-    bs::Vector<bs::Path> filterFilesInDirectoryByExt(const bs::Path& path, const bs::String& ext);
+    bs::Vector<bs::Path> filterFilesInDirectoryByExt(const bs::Path& path, const bs::String& ext) const;
 
     /**
      * @return Actual path to the data-directory
      */
-    bs::Path dataDirectory();
+    bs::Path dataDirectory() const;
 
     /**
      * Given a case-insensitive path, this tries to find the real, case-sensitive path.
@@ -74,7 +80,7 @@ namespace REGoth
      * @param  path  Case-insensitive path to look at relative to the game root.
      * @return First file that matched the case insensitive path.
      */
-    bs::Path findCaseSensitivePathOf(const bs::Path& path);
+    bs::Path findCaseSensitivePathOf(const bs::Path& path) const;
 
     /**
      * Given a directory and the name of a directory or file, this will try to find
@@ -89,7 +95,7 @@ namespace REGoth
      * @return Input path with the given directory or file appended in the correct case.
      *         bs::Path::BLANK if the given directory or file was not found.
      */
-    bs::Path appendCaseInsensitiveThing(const bs::Path& path, const bs::String& thing);
+    bs::Path appendCaseInsensitiveThing(const bs::Path& path, const bs::String& thing) const;
 
     /**
      * Root of the original game directory

--- a/src/original-content/VirtualFileSystem.hpp
+++ b/src/original-content/VirtualFileSystem.hpp
@@ -35,6 +35,7 @@
 
 #pragma once
 
+#include <BsPrerequisites.h>
 #include <FileSystem/BsPath.h>
 
 namespace VDFS
@@ -75,6 +76,19 @@ namespace REGoth
      * @return Whether the package could be loaded.
      */
     bool loadPackage(const bs::Path& package);
+
+    /**
+     * Mounts the directory at the given path.
+     *
+     * The directory-structure itself will be flattened so basically the directory
+     * is recursivly searched and all files are added to the index at root level.
+     *
+     * Throws if the given path does not end in a valid directory or if the VDFS
+     * was already finalized (happens on first file read).
+     *
+     * @param  path  Path of the directory to add.
+     */
+    void mountDirectory(const bs::Path& path);
 
     /**
      * Returns a list of all files known to the index.

--- a/src/original-content/VirtualFileSystem.hpp
+++ b/src/original-content/VirtualFileSystem.hpp
@@ -62,45 +62,19 @@ namespace REGoth
     void setPathToEngineExecutable(const bs::String& argv0);
 
     /**
-     * Before the VDFS can load packages, it needs to know where gothics data files are,
-     * which can be set using this function.
-     *
-     * @param gameDirectory  Path to gothics root directory
-     */
-    void setGameDirectory(const bs::Path& gameDirectory);
-
-    /**
-     * Checks gothics data-directory for a package with the given name (case-insensitive).
-     *
-     * @note Needs a game directory to work. See setGameDirectory().
-     *
-     * @param  package  Name of the package, with extension (eg. "Meshes.vdf").
-     *
-     * @return Whether the given package is available.
-     */
-    bool isPackageAvailable(const bs::String& package) const;
-
-    /**
      * Loads a package into the global file index.
      *
-     * The package will be loaded from the games data directory, if possible.
      * After loading, the files of the given package can be found inside the
      * file index and their data can be obtained using readFile().
-     *
-     * To check whether a package exists, call isPackageAvailable(). However,
-     * loadPackage() *will* do the same check inside and return whether the
-     * package exists.
      *
      * Also not that you *cannot* load more packages after you have read the
      * first file. Make sure to load all packages first.
      *
-     * @note   Needs a game directory to work. See setGameDirectory().
-     *
-     * @param  package  Name of the package, with extension (eg. "Meshes.vdf").
+     * @param  package  Path of the package to load.
      *
      * @return Whether the package could be loaded.
      */
-    bool loadPackage(const bs::String& package);
+    bool loadPackage(const bs::Path& package);
 
     /**
      * Returns a list of all files known to the index.

--- a/src/scripting/ScriptVMInterface.cpp
+++ b/src/scripting/ScriptVMInterface.cpp
@@ -1,4 +1,5 @@
 #include "ScriptVMInterface.hpp"
+#include <daedalus/DATFile.h>
 
 namespace REGoth
 {
@@ -6,9 +7,11 @@ namespace REGoth
   {
     static bs::SPtr<ScriptVMInterface> s_GameScript = nullptr;
 
-    void loadGothicDAT(const Daedalus::DATFile& datFile)
+    void loadGothicDAT(const bs::Vector<bs::UINT8>& gothicDAT)
     {
-      s_GameScript = bs::bs_unique_ptr_new<ScriptVMInterface>(datFile);
+      Daedalus::DATFile dat(gothicDAT.data(), gothicDAT.size());
+
+      s_GameScript = bs::bs_unique_ptr_new<ScriptVMInterface>(dat);
       s_GameScript->initialize();
     }
 

--- a/src/scripting/ScriptVMInterface.hpp
+++ b/src/scripting/ScriptVMInterface.hpp
@@ -31,8 +31,10 @@ namespace REGoth
      * Initializes the scripting system with a Gothic DAT-File.
      * If this is called a second time, everything will be scrapped,
      * all existing handles will be invalidated.
+     *
+     * @param  gothicDAT  Byte-Data of the GOTHIC.DAT to load.
      */
-    void loadGothicDAT(const Daedalus::DATFile& datFile);
+    void loadGothicDAT(const bs::Vector<bs::UINT8>& gothicDAT);
   }
 
   /**


### PR DESCRIPTION
This class provides easy access to the original game files for all platforms.
                                                                             
Since Gothic was developed on Windows-Systems, which uses a case-insensitive 
file system, there are major differences in file naming between releases.    
Sometimes a folder is called `Data`, `DATA` or `data`, you get the idea.     
                                                                             
This is troublesome for UNIX-systems which generally use case-sensitive      
file systems.                                                                
                                                                             
Another reason this class exists is so we can abstract away the paths to     
certain files used by the engine.                                            
                                                                             
Generally, all paths you get back are in the correct case for your system.   