### PR TITLE
Node attachments

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(REGothEngine
   components/VisualSkeletalAnimation.cpp
   components/VisualStaticMesh.hpp
   components/VisualStaticMesh.cpp
+  components/VisualInteractiveObject.hpp
+  components/VisualInteractiveObject.cpp
   components/StartSpot.hpp
   components/StartSpot.cpp
   components/Spot.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,8 @@ add_library(REGothEngine
   components/CharacterState.cpp
   components/VisualCharacter.hpp
   components/VisualCharacter.cpp
+  components/VisualSkeletalAnimation.hpp
+  components/VisualSkeletalAnimation.cpp
   components/VisualStaticMesh.hpp
   components/VisualStaticMesh.cpp
   components/StartSpot.hpp
@@ -115,3 +117,6 @@ target_link_libraries(REGothWaynetTester REGothEngine samples-common)
 
 add_executable(REGothCharacterMovementTester main_CharacterMovementTest.cpp)
 target_link_libraries(REGothCharacterMovementTester REGothEngine samples-common)
+
+add_executable(REGothMobViewer main_MobViewer.cpp)
+target_link_libraries(REGothMobViewer REGothEngine samples-common)

--- a/src/REGothEngine.cpp
+++ b/src/REGothEngine.cpp
@@ -1,6 +1,7 @@
 #include "REGothEngine.hpp"
 #include <BsApplication.h>
 #include <assert.h>
+#include <BsZenLib/ResourceManifest.hpp>
 #include "original-content/VirtualFileSystem.hpp"
 #include <BsZenLib/ImportPath.hpp>
 #include <Components/BsCCamera.h>
@@ -55,22 +56,7 @@ void REGothEngine::loadCachedResourceManifests()
 
   gDebug().logDebug("[REGothEngine] Loading cached resource manifests");
 
-  if (FileSystem::exists(BsZenLib::GothicPathToCachedManifest("resources")))
-  {
-    auto prevManifest = ResourceManifest::load(BsZenLib::GothicPathToCachedManifest("resources"),
-                                               BsZenLib::GetCacheDirectory());
-
-    gResources().registerResourceManifest(prevManifest);
-  }
-}
-
-void REGothEngine::saveCachedResourceManifests()
-{
-  using namespace bs;
-
-  SPtr<ResourceManifest> manifest = gResources().getResourceManifest("Default");
-  ResourceManifest::save(manifest, BsZenLib::GothicPathToCachedManifest("resources"),
-                         BsZenLib::GetCacheDirectory());
+  BsZenLib::LoadResourceManifest();
 }
 
 void REGothEngine::setupInput()
@@ -184,8 +170,6 @@ int ::REGoth::main(REGothEngine& regoth, int argc, char** argv)
   regoth.setupInput();
   regoth.setupMainCamera();
   regoth.setupScene();
-
-  regoth.saveCachedResourceManifests();
 
   regoth.run();
 

--- a/src/REGothEngine.hpp
+++ b/src/REGothEngine.hpp
@@ -60,11 +60,6 @@ namespace REGoth
     void loadCachedResourceManifests();
 
     /**
-     * Saves all resources currently registered in the resource manager to a manifest.
-     */
-    void saveCachedResourceManifests();
-
-    /**
      * Assign buttons and axis to control the game
      */
     virtual void setupInput();

--- a/src/RTTI/RTTI_TypeIDs.hpp
+++ b/src/RTTI/RTTI_TypeIDs.hpp
@@ -5,10 +5,11 @@ namespace REGoth
   // See BsCorePrerequisites.h, TypeID_Core
   enum TypeID_REGoth
   {
-    TID_REGOTH_VisualCharacter        = 60000,
-    TID_REGOTH_Character              = 60001,
-    TID_REGOTH_ScriptBackedBy         = 60002,
-    TID_REGOTH_CharacterKeyboardInput = 60003,
-    TID_REGOTH_CharacterAI            = 60004,
+    TID_REGOTH_VisualCharacter         = 60000,
+    TID_REGOTH_Character               = 60001,
+    TID_REGOTH_ScriptBackedBy          = 60002,
+    TID_REGOTH_CharacterKeyboardInput  = 60003,
+    TID_REGOTH_CharacterAI             = 60004,
+    TID_REGOTH_VisualSkeletalAnimation = 60005,
   };
 }  // namespace REGoth

--- a/src/RTTI/RTTI_TypeIDs.hpp
+++ b/src/RTTI/RTTI_TypeIDs.hpp
@@ -11,5 +11,6 @@ namespace REGoth
     TID_REGOTH_CharacterKeyboardInput  = 60003,
     TID_REGOTH_CharacterAI             = 60004,
     TID_REGOTH_VisualSkeletalAnimation = 60005,
+    TID_REGOTH_VisualInteractiveObject = 60006,
   };
 }  // namespace REGoth

--- a/src/RTTI/RTTI_VisualInteractiveObject.hpp
+++ b/src/RTTI/RTTI_VisualInteractiveObject.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "RTTI_TypeIDs.hpp"
+#include <BsCorePrerequisites.h>
+#include <Private/RTTI/BsGameObjectRTTI.h>  // Says private, but bs:f uses this too in their RTTIs
+#include <Reflection/BsRTTIType.h>
+#include <components/VisualInteractiveObject.hpp>
+
+namespace REGoth
+{
+  class RTTI_VisualInteractiveObject
+      : public bs::RTTIType<VisualInteractiveObject, VisualSkeletalAnimation,
+                            RTTI_VisualInteractiveObject>
+  {
+    BS_BEGIN_RTTI_MEMBERS
+    // TODO: Fill RTTI Members
+    BS_END_RTTI_MEMBERS
+
+  public:
+    RTTI_VisualInteractiveObject()
+    {
+    }
+
+    bs::SPtr<bs::IReflectable> newRTTIObject() override
+    {
+      return bs::GameObjectRTTI::createGameObject<VisualInteractiveObject>();
+    }
+
+    const bs::String& getRTTIName() override
+    {
+      static bs::String name = "VisualInteractiveObject";
+      return name;
+    }
+
+    bs::UINT32 getRTTIId() override
+    {
+      return TID_REGOTH_VisualInteractiveObject;
+    }
+  };
+
+}  // namespace REGoth

--- a/src/RTTI/RTTI_VisualSkeletalAnimation.hpp
+++ b/src/RTTI/RTTI_VisualSkeletalAnimation.hpp
@@ -4,36 +4,36 @@
 #include <BsCorePrerequisites.h>
 #include <Private/RTTI/BsGameObjectRTTI.h>  // Says private, but bs:f uses this too in their RTTIs
 #include <Reflection/BsRTTIType.h>
-#include <components/VisualCharacter.hpp>
+#include <components/VisualSkeletalAnimation.hpp>
 
 namespace REGoth
 {
-  class RTTI_VisualCharacter
-      : public bs::RTTIType<VisualCharacter, VisualSkeletalAnimation, RTTI_VisualCharacter>
+  class RTTI_VisualSkeletalAnimation
+    : public bs::RTTIType<VisualSkeletalAnimation, bs::Component, RTTI_VisualSkeletalAnimation>
   {
     BS_BEGIN_RTTI_MEMBERS
     // TODO: Fill RTTI Members
     BS_END_RTTI_MEMBERS
 
-  public:
-    RTTI_VisualCharacter()
+    public:
+    RTTI_VisualSkeletalAnimation()
     {
     }
 
     bs::SPtr<bs::IReflectable> newRTTIObject() override
     {
-      return bs::GameObjectRTTI::createGameObject<VisualCharacter>();
+      return bs::GameObjectRTTI::createGameObject<VisualSkeletalAnimation>();
     }
 
     const bs::String& getRTTIName() override
     {
-      static bs::String name = "VisualCharacter";
+      static bs::String name = "VisualSkeletalAnimation";
       return name;
     }
 
     bs::UINT32 getRTTIId() override
     {
-      return TID_REGOTH_VisualCharacter;
+      return TID_REGOTH_VisualSkeletalAnimation;
     }
   };
 

--- a/src/components/NodeVisuals.cpp
+++ b/src/components/NodeVisuals.cpp
@@ -1,4 +1,5 @@
 #include "NodeVisuals.hpp"
+#include <Components/BsCRenderable.h>
 #include <Animation/BsSkeleton.h>
 #include <Components/BsCBone.h>
 #include <Components/BsCRenderable.h>
@@ -32,19 +33,15 @@ namespace REGoth
   {
     clearNodeAttachment(node);
 
-    assert(hasNode(node));
-
-    bs::SPtr<bs::Skeleton> skeleton = getSkeleton();
-
-    // for (bs::UINT32 i = 0; i < skeleton->getNumBones(); i++)
-    // {
-    //   bs::gDebug().logDebug("Bone: " + skeleton->getBoneInfo(i).name);
-    // }
-
     bs::HSceneObject boneSO = bs::SceneObject::create(node);
 
-    bool dontKeepWorldTransform = false;
-    boneSO->setParent(SO(), dontKeepWorldTransform);
+    enum
+    {
+      KeepWorldTransform = true,
+      MoveRelativeToParent = false,
+    };
+
+    boneSO->setParent(SO(), MoveRelativeToParent);
 
     bs::HBone bone = boneSO->addComponent<bs::CBone>();
     bone->setBoneName(node);
@@ -58,6 +55,28 @@ namespace REGoth
       bs::gDebug().logWarning("[NodeVisuals] Failed to attach visual '" + visual + "' to node '" +
                               node + "'");
     }
+  }
+
+  void NodeVisuals::attachMeshToNode(const bs::String& node, BsZenLib::Res::HMeshWithMaterials mesh)
+  {
+    clearNodeAttachment(node);
+
+    bs::HSceneObject boneSO = bs::SceneObject::create(node);
+
+    enum
+    {
+      KeepWorldTransform   = true,
+      MoveRelativeToParent = false,
+    };
+
+    boneSO->setParent(SO(), MoveRelativeToParent);
+
+    bs::HBone bone = boneSO->addComponent<bs::CBone>();
+    bone->setBoneName(node);
+
+    bs::HRenderable renderable = boneSO->addComponent<bs::CRenderable>();
+    renderable->setMesh(mesh->getMesh());
+    renderable->setMaterials(mesh->getMaterials());
   }
 
   void NodeVisuals::clearNodeAttachment(const bs::String& node)

--- a/src/components/NodeVisuals.hpp
+++ b/src/components/NodeVisuals.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <BsPrerequisites.h>
+#include <BsZenLib/ZenResources.hpp>
 #include <Scene/BsComponent.h>
 
 namespace REGoth
@@ -36,6 +37,17 @@ namespace REGoth
     void attachVisualToNode(const bs::String& node, const bs::String& visual);
 
     /**
+     * Attaches the given mesh to the given node.
+     *
+     * Existing attachments will be replaced.
+     * If the node cannot be found, then nothing happens.
+     *
+     * @param  node    The node name to attach to, e.g. `BIP01 HEAD`.
+     * @param  visual  The original file name of the visual, e.g. `STONE.3DS`.
+     */
+    void attachMeshToNode(const bs::String& node, BsZenLib::Res::HMeshWithMaterials mesh);
+
+    /**
      * Removes the current attachment from the given node, if one exists.
      *
      * @param  node  Name of the node to remove the attached visual from.
@@ -43,7 +55,6 @@ namespace REGoth
     void clearNodeAttachment(const bs::String& node);
 
   private:
-
     /**
      * @return The current skeleton used by the scene objects renderable component.
      */
@@ -51,4 +62,4 @@ namespace REGoth
   };
 
   using HNodeVisuals = bs::GameObjectHandle<NodeVisuals>;
-}
+}  // namespace REGoth

--- a/src/components/Visual.cpp
+++ b/src/components/Visual.cpp
@@ -1,4 +1,5 @@
 #include "Visual.hpp"
+#include "VisualInteractiveObject.hpp"
 #include "VisualMorphMesh.hpp"
 #include "VisualStaticMesh.hpp"
 #include <Scene/BsSceneObject.h>
@@ -7,15 +8,27 @@ namespace REGoth
 {
   Visual::VisualKind Visual::guessVisualKind(const bs::String& visual)
   {
-    const bool lowercase = true;
+    enum
+    {
+      CompareCaseSensitive = false,
+      ConvertToLowercase   = true,
+    };
 
-    if (bs::StringUtil::endsWith(visual, ".3ds", lowercase))
+    if (bs::StringUtil::endsWith(visual, ".3ds", ConvertToLowercase))
     {
       return VisualKind::StaticMesh;
     }
-    else if (bs::StringUtil::endsWith(visual, ".mmb", lowercase))
+    else if (bs::StringUtil::endsWith(visual, ".mmb", ConvertToLowercase))
     {
       return VisualKind::MorphMesh;
+    }
+    else if (bs::StringUtil::endsWith(visual, ".mms", ConvertToLowercase))
+    {
+      return VisualKind::MorphMesh;
+    }
+    else if (bs::StringUtil::endsWith(visual, ".asc", ConvertToLowercase))
+    {
+      return VisualKind::InteractiveObject;
     }
     else
     {
@@ -39,6 +52,14 @@ namespace REGoth
     {
       HVisualMorphMesh mesh = so->addComponent<VisualMorphMesh>();
       mesh->setMesh(visual);
+
+      return true;
+    }
+    if (kind == VisualKind::InteractiveObject)
+    {
+      HVisualInteractiveObject mesh = so->addComponent<VisualInteractiveObject>();
+
+      mesh->setVisual(visual);
 
       return true;
     }

--- a/src/components/Visual.hpp
+++ b/src/components/Visual.hpp
@@ -9,7 +9,7 @@ namespace REGoth
     {
       StaticMesh,
       MorphMesh,
-      SkeletalMesh,
+      InteractiveObject,
       Decal,
       Particles,
       Unknown,
@@ -22,6 +22,10 @@ namespace REGoth
      * instance matching the files type. For example, a `.3DS` file is handled by the
      * `StaticMesh`-Visual (`zCProgMeshProto` in the original).
      *
+     * @note   This will assume all `.ASC` files to be an interactive object, while
+     *         `.ASC` are also used for character models. So don't use this function
+     *         for characters, please.
+     *
      * @param  visual  File name of the visual, e.g. `STONE.3DS`.
      *
      * @return Which kind of visual the given filename should use.
@@ -32,6 +36,10 @@ namespace REGoth
      * Creates a matching visual component and attaches it to the given scene object.
      *
      * For example `STONE.3DS` will create a static mesh visual component.
+     *
+     * @note   This will assume all `.ASC` files to be an interactive object, while
+     *         `.ASC` are also used for character models. So don't use this function
+     *         for characters, please.
      *
      * @param  so      Scene-Object to create the component for.
      * @param  visual  Name of the visual to create (The filename, that is), like `STONE.3DS`.

--- a/src/components/VisualCharacter.cpp
+++ b/src/components/VisualCharacter.cpp
@@ -24,7 +24,7 @@ const bs::String MODEL_NODE_NAME_FOOTSTEPS = " FOOTSTEPS";
 namespace REGoth
 {
   VisualCharacter::VisualCharacter(const bs::HSceneObject& parent)
-    : VisualSkeletalAnimation(parent)
+      : VisualSkeletalAnimation(parent)
   {
     setName("VisualCharacter");
   }
@@ -93,6 +93,11 @@ namespace REGoth
     }
 
     // TODO: Fix texture and color
+  }
+
+  bs::Vector<bs::String> VisualCharacter::listPossibleDefaultAnimations() const
+  {
+    return {"S_RUN", "S_FISTRUN"};
   }
 
   bs::RTTITypeBase* VisualCharacter::getRTTIStatic()

--- a/src/components/VisualCharacter.hpp
+++ b/src/components/VisualCharacter.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
+#include "VisualSkeletalAnimation.hpp"
 #include <BsPrerequisites.h>
-#include <BsZenLib/ZenResources.hpp>
 #include <Scene/BsComponent.h>
 
 namespace REGoth
@@ -16,53 +16,16 @@ namespace REGoth
   /**
    * Component for rendering an animated character (Player, NPC, Monster).
    *
-   * This component will take care of loading the correct resources and has
-   * an interface to play animations. It can also be configured such that
-   * the root-motion of the played animation is applied to the scene object.
+   * This component extends the VisualSkeletalAnimation-Component and
+   * adds support for character specific features, such as
    *
-   * # Object tree
-   *
-   * Because of the way bsf works, one cannot modify any transforms like scaling
-   * or rotation if root-motion is used on a scene object. Therefore the actual
-   * characters renderable and animation components are put into a sub-object.
-   *
-   * This sub-object will also handle all visual node attachments.
-   *
-   * # Model script files
-   *
-   * In Gothic, similar creatures and characters are described inside a so called
-   * *model script file*. Inside this file, every mesh matching the animation
-   * node tree is listed, along with all possible animations and their properties.
-   *
-   * Therefore, this component needs to know the model script and the mesh
-   * that it should display from that model script.
+   *  - setting the body and head meshes with the correct textures
+   *  - Easy access to some node attachments, like the left and right hand
    */
-  class VisualCharacter : public bs::Component
+  class VisualCharacter : public VisualSkeletalAnimation
   {
   public:
     VisualCharacter(const bs::HSceneObject& parent);
-
-    /**
-     * Set which model script this component should read the list of possible
-     * meshes and animations from. This **must** be set for the component to work.
-     */
-    void setModelScript(BsZenLib::Res::HModelScriptFile modelScript);
-
-    /**
-     * Set the mesh this component should display. This mesh **must** come from
-     * within the given model script file, otherwise the component won't display
-     * the mesh.
-     */
-    void setMesh(BsZenLib::Res::HMeshWithMaterials mesh);
-
-    /**
-     * Sets up the visual according to the given visual name.
-     *
-     * Throws if that visual does not exist.
-     *
-     * @param  visual  Name of the visual (model-script) to use, e.g. `HUMANS.MDS`.
-     */
-    void setVisual(const bs::String& visual);
 
     /**
      * Sets the body mesh.
@@ -84,123 +47,7 @@ namespace REGoth
     void setHeadMesh(const bs::String& headmesh, bs::UINT32 headTextureIdx = 0,
                      bs::UINT32 teethTextureIdx = 0);
 
-    /**
-     * Calculates how far the characters animation has moved since the last
-     * call ot this function via animation.
-     *
-     * @return Delta between the animation postion when this function was called
-     *         the last time and now.
-     */
-    bs::Vector3 resolveFrameRootMotion();
-
-    /**
-     * @return The bounds of the underlaying renderable
-     */
-    bs::Bounds getBounds() const;
-
-    /**
-     * Find the animation clip matching the currently set model script and overlay.
-     * Returns an invalid handle when the was not found.
-     *
-     * @param  name  The UPPERCASE animation name (`S_RUNL`)
-     *
-     * @return Animation clip for the given animation name. Invalid if not found.
-     */
-    bs::HAnimationClip findAnimationClip(const bs::String& name) const;
-
-    /**
-     * Plays the given animation clip.
-     */
-    void playAnimation(bs::HAnimationClip clip);
-
-    /**
-     * Searches for the default idle animation for this character and plays it.
-     *
-     * The idle animation for humans is `S_RUN`. For monsters, that one doesn't exist
-     * since they are always in the *Fist*-Weaponmode. Therefore `S_FISTRUN` is being
-     * played instead.
-     *
-     * This method should be only for for testing, since playing the correct animations
-     * should be handled by other parts of the software.
-     */
-    void playDefaultIdleAnimation();
-
-    /**
-     * Tries to transition to the given animation name.
-     *
-     * @param  Animation to transition to, eg `S_RUNL` or `T_JUMPB`.
-     *
-     * @return true, if the transition was possible.
-     */
-    bool tryPlayTransitionAnimationTo(const bs::String& state);
-
-    /**
-     * @return Whether the given animation is currently playing
-     */
-    bool isAnimationPlaying(bs::HAnimationClip clip) const;
-
-    /**
-     * @return Name of the currently playing animation. Empty string if none.
-     */
-    bs::String getPlayingAnimationName() const;
-
-    /**
-     * @return The current state animations state, eg. `RUNL` for `S_RUNL`.
-     */
-    bs::String getStateFromPlayingAnimation() const;
-
-    /**
-     * Whether the currently playing animation can be interrupted by the user.
-     *
-     * This will return false on animations like jumping backwards or
-     * falling onto the floor when dying.
-     *
-     * If no animation is played, true is returned.
-     *
-     * @return Whether the user can interrupt the currently playing animation.
-     */
-    bool isPlayingAnimationInterruptable() const;
-
   private:
-    /**
-     * @return Whether the given mesh is registered inside the currently set model script
-     */
-    bool isMeshRegisteredInModelScript(BsZenLib::Res::HMeshWithMaterials mesh);
-
-    /**
-     * Deletes all sub objects created by this component (ie. for rendering)
-     */
-    void deleteObjectSubtree();
-
-    /**
-     * (Re)creates all sub objects needed ie. for rendering.
-     */
-    void buildObjectSubtree();
-
-    /**
-     * Creates the sub object and all components needed on that object.
-     */
-    void createAndRegisterSubComponents();
-
-    /**
-     * Creates a sub-object and adds it to the list of all sub-objects.
-     */
-    bs::HSceneObject createAndRegisterSubObject(const bs::String& name);
-
-    /**
-     * Sets up the empty previously created renderable component.
-     */
-    void setupRenderableComponent();
-
-    /**
-     * Sets up the empty previously create animation component.
-     */
-    void setupAnimationComponent();
-
-    /**
-     * Called when a animation event was triggered
-     */
-    void onAnimationEvent(const bs::HAnimationClip& clip, bs::String string);
 
     /**
      * Replaces the current body mesh of this model from the current body-state
@@ -214,34 +61,16 @@ namespace REGoth
 
     struct BodyState
     {
-      bs::String headVisual = "";
-      bs::String bodyVisual = "";
-      bs::UINT32 headTextureIdx = 0;
-      bs::UINT32 teethTextureIdx = 0;
+      bs::String headVisual       = "";
+      bs::String bodyVisual       = "";
+      bs::UINT32 headTextureIdx   = 0;
+      bs::UINT32 teethTextureIdx  = 0;
       bs::UINT32 bodySkinColorIdx = 0;
-      bs::UINT32 bodyTextureIdx = 0;
+      bs::UINT32 bodyTextureIdx   = 0;
     };
 
     // Body Visual Settings ---------------------------------------------------
     BodyState mBodyState;
-
-    // Object Sub Tree --------------------------------------------------------
-    bs::Vector<bs::HSceneObject> mSubObjects; /**< All created sub-objects by this component */
-
-    bs::HRenderable mSubRenderable; /**< The Renderable created inside a sub object */
-    bs::HAnimation mSubAnimation;   /**< The Animation-Component created inside a sub object */
-    HNodeVisuals mSubNodeVisuals;   /**< The NodeVisuals-Component created inside a sub object */
-
-    // Configuration ----------------------------------------------------------
-
-    BsZenLib::Res::HModelScriptFile mModelScript; /**< Model-script of the displayed model */
-    BsZenLib::Res::HMeshWithMaterials mMesh; /**< Currently displayed mesh, from the model script */
-
-    // Animation --------------------------------------------------------------
-    bs::Map<bs::String, bs::HAnimationClip> mAnimationClips; /**< Animation names -> clip */
-    bs::HAnimationClip mRootMotionLastClip; /**< Last clip we got the root motion from */
-    float mRootMotionLastTime = 0.0f; /**< Last time the animation was queried for root motion */
-
 
     /************************************************************************/
     /* 								RTTI */
@@ -251,8 +80,8 @@ namespace REGoth
     static bs::RTTITypeBase* getRTTIStatic();
     bs::RTTITypeBase* getRTTI() const override;
 
-  // protected:
-  public: // FIXME: Should be protected, it is only used by RRIT but `friend` doesn't seem to work?!
+    // protected:
+  public:  // FIXME: Should be protected, it is only used by RRIT but `friend` doesn't seem to work?!
     VisualCharacter() = default;  // Serialization only
   };
 

--- a/src/components/VisualCharacter.hpp
+++ b/src/components/VisualCharacter.hpp
@@ -47,6 +47,10 @@ namespace REGoth
     void setHeadMesh(const bs::String& headmesh, bs::UINT32 headTextureIdx = 0,
                      bs::UINT32 teethTextureIdx = 0);
 
+  protected:
+
+    bs::Vector<bs::String> listPossibleDefaultAnimations() const override;
+
   private:
 
     /**

--- a/src/components/VisualInteractiveObject.cpp
+++ b/src/components/VisualInteractiveObject.cpp
@@ -1,0 +1,30 @@
+#include "VisualInteractiveObject.hpp"
+#include <RTTI/RTTI_VisualInteractiveObject.hpp>
+
+namespace REGoth
+{
+  VisualInteractiveObject::VisualInteractiveObject(const bs::HSceneObject& parent)
+      : VisualSkeletalAnimation(parent)
+  {
+    setName("VisualInteractiveObject");
+  }
+
+  VisualInteractiveObject::~VisualInteractiveObject()
+  {
+  }
+
+  bs::Vector<bs::String> VisualInteractiveObject::listPossibleDefaultAnimations() const
+  {
+    return {"S_S0"};
+  }
+
+  bs::RTTITypeBase* VisualInteractiveObject::getRTTIStatic()
+  {
+    return RTTI_VisualInteractiveObject::instance();
+  }
+
+  bs::RTTITypeBase* VisualInteractiveObject::getRTTI() const
+  {
+    return VisualInteractiveObject::getRTTIStatic();
+  }
+}  // namespace REGoth

--- a/src/components/VisualInteractiveObject.hpp
+++ b/src/components/VisualInteractiveObject.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include "VisualSkeletalAnimation.hpp"
+#include <BsPrerequisites.h>
+#include <Scene/BsComponent.h>
+
+namespace REGoth
+{
+  /**
+   * Component for rendering an interactive object (Called Mob in the original).
+   *
+   * This component extends the VisualSkeletalAnimation-Component and
+   * adds support for interactive object specific features.
+   */
+  class VisualInteractiveObject : public VisualSkeletalAnimation
+  {
+  public:
+    VisualInteractiveObject (const bs::HSceneObject& parent);
+    virtual ~VisualInteractiveObject ();
+
+  protected:
+
+    bs::Vector<bs::String> listPossibleDefaultAnimations() const override;
+
+  private:
+
+    /************************************************************************/
+    /* RTTI                                                                 */
+    /************************************************************************/
+  public:
+    friend class RTTI_VisualInteractiveObject ;
+    static bs::RTTITypeBase* getRTTIStatic();
+    bs::RTTITypeBase* getRTTI() const override;
+
+    // protected:
+  public:  // FIXME: Should be protected, it is only used by RTTI but friend doesn't seem to work?!
+    VisualInteractiveObject () = default;  // Serialization only
+  };
+}  // namespace REGoth

--- a/src/components/VisualInteractiveObject.hpp
+++ b/src/components/VisualInteractiveObject.hpp
@@ -35,4 +35,6 @@ namespace REGoth
   public:  // FIXME: Should be protected, it is only used by RTTI but friend doesn't seem to work?!
     VisualInteractiveObject () = default;  // Serialization only
   };
+
+  using HVisualInteractiveObject = bs::GameObjectHandle<VisualInteractiveObject>;
 }  // namespace REGoth

--- a/src/components/VisualSkeletalAnimation.cpp
+++ b/src/components/VisualSkeletalAnimation.cpp
@@ -85,6 +85,21 @@ namespace REGoth
     }
   }
 
+  void VisualSkeletalAnimation::useFirstMeshOfModelScript()
+  {
+    if (!mModelScript)
+    {
+      REGOTH_THROW(InvalidStateException, "Expected Model Script but none was set!");
+    }
+
+    if (mModelScript->getMeshes().empty())
+    {
+      REGOTH_THROW(InvalidStateException, "Model Script seems to not have any meshes!");
+    }
+
+    setMesh(mModelScript->getMeshes()[0]);
+  }
+
   void VisualSkeletalAnimation::setVisual(const bs::String& visual)
   {
     BsZenLib::Res::HModelScriptFile modelScript;
@@ -111,6 +126,9 @@ namespace REGoth
     }
 
     setModelScript(modelScript);
+
+    // Using the first registered mesh as the default seems to be like the original is doing it
+    useFirstMeshOfModelScript();
   }
 
   bs::Bounds VisualSkeletalAnimation::getBounds() const

--- a/src/components/VisualSkeletalAnimation.cpp
+++ b/src/components/VisualSkeletalAnimation.cpp
@@ -1,0 +1,430 @@
+#include "VisualSkeletalAnimation.hpp"
+#include <RTTI/RTTI_VisualSkeletalAnimation.hpp>
+
+#include "VisualSkeletalAnimation.hpp"
+#include "original-content/VirtualFileSystem.hpp"
+#include <Animation/BsAnimationClip.h>
+#include <BsZenLib/ImportPath.hpp>
+#include <BsZenLib/ImportSkeletalMesh.hpp>
+#include <Components/BsCAnimation.h>
+#include <Components/BsCRenderable.h>
+#include <Debug/BsDebug.h>
+#include <Mesh/BsMesh.h>
+#include <RTTI/RTTI_VisualCharacter.hpp>
+#include <Scene/BsSceneObject.h>
+#include <animation/Animation.hpp>
+#include <animation/StateNaming.hpp>
+#include <components/NodeVisuals.hpp>
+#include <excepction/Throw.hpp>
+
+namespace REGoth
+{
+  VisualSkeletalAnimation::VisualSkeletalAnimation(const bs::HSceneObject& parent)
+      : bs::Component(parent)
+  {
+    setName("VisualSkeletalAnimation");
+  }
+
+  void VisualSkeletalAnimation::throwIfNotReadyForRendering() const
+  {
+    if (!mModelScript)
+    {
+      REGOTH_THROW(InvalidStateException, "Expected Model Script but none was set!");
+    }
+
+    if (!mMesh)
+    {
+      REGOTH_THROW(InvalidStateException, "Expected Mesh but none was set!");
+    }
+
+    if (!mSubRenderable || !mSubAnimation || !mSubNodeVisuals)
+    {
+      REGOTH_THROW(InvalidStateException, "Missing sub-component!");
+    }
+  }
+
+  void VisualSkeletalAnimation::setModelScript(BsZenLib::Res::HModelScriptFile modelScript)
+  {
+    if (modelScript->getName().empty())
+    {
+      REGOTH_THROW(InvalidParametersException, "ModelScript should have a name!");
+    }
+
+    deleteObjectSubtree();
+    mModelScript = modelScript;
+
+    for (bs::HAnimationClip clip : mModelScript->getAnimationClips())
+    {
+      mAnimationClips[clip->getName()] = clip;
+      // bs::gDebug().logDebug(clip->getName());
+    }
+  }
+
+  void VisualSkeletalAnimation::setMesh(BsZenLib::Res::HMeshWithMaterials mesh)
+  {
+    using namespace bs;
+
+    if (isMeshRegisteredInModelScript(mesh))
+    {
+      mMesh = mesh;
+
+      deleteObjectSubtree();
+      buildObjectSubtree();
+
+      addDefaultAttachments();
+
+      // TODO: This is only in while we don't have a proper animation controller/AI. Remove once
+      //       that is in!
+      playDefaultIdleAnimation();
+    }
+    else
+    {
+      REGOTH_THROW(InvalidParametersException,
+                   "Mesh " + mesh->getName() + " is not part of set model-script " +
+                       (mModelScript ? mModelScript->getName() : "<none>"));
+    }
+  }
+
+  void VisualSkeletalAnimation::setVisual(const bs::String& visual)
+  {
+    BsZenLib::Res::HModelScriptFile modelScript;
+
+    // FIXME: Loading these from cache does work in the character viewer, but not in the world
+    // viewer?! This set is just a workaround so we always use model scripts from this run
+    // while caching only one of it. It should be removed once that is figured out.
+    static bs::Set<bs::String> s_cachedVisuals;
+    bool hasCachedItThisRun = s_cachedVisuals.find(visual) != s_cachedVisuals.end();
+
+    if (hasCachedItThisRun && BsZenLib::HasCachedMDS(visual))
+    {
+      modelScript = BsZenLib::LoadCachedMDS(visual);
+    }
+    else
+    {
+      modelScript = BsZenLib::ImportAndCacheMDS(visual, REGoth::gVirtualFileSystem().getFileIndex());
+      s_cachedVisuals.insert(visual);
+    }
+
+    if (!modelScript)
+    {
+      REGOTH_THROW(InvalidParametersException, "Model Script " + visual + " could not be loaded!");
+    }
+
+    setModelScript(modelScript);
+  }
+
+  bs::Bounds VisualSkeletalAnimation::getBounds() const
+  {
+    return mSubRenderable ? mSubRenderable->getBounds() : bs::Bounds();
+  }
+
+  bool VisualSkeletalAnimation::isMeshRegisteredInModelScript(BsZenLib::Res::HMeshWithMaterials mesh)
+  {
+    if (!mModelScript) return false;
+
+    for (const auto& m : mModelScript->getMeshes())
+    {
+      if (m == mesh) return true;
+    }
+
+    return false;
+  }
+
+  void VisualSkeletalAnimation::deleteObjectSubtree()
+  {
+    for (bs::HSceneObject h : mSubObjects)
+    {
+      h->destroy();
+    }
+
+    mSubObjects.clear();
+  }
+
+  void VisualSkeletalAnimation::buildObjectSubtree()
+  {
+    createAndRegisterSubComponents();
+
+    setupRenderableComponent();
+    setupAnimationComponent();
+  }
+
+  void VisualSkeletalAnimation::createAndRegisterSubComponents()
+  {
+    bs::HSceneObject renderSO = createAndRegisterSubObject("Renderable");
+
+    mSubRenderable  = renderSO->addComponent<bs::CRenderable>();
+    mSubAnimation   = renderSO->addComponent<bs::CAnimation>();
+    mSubNodeVisuals = renderSO->addComponent<NodeVisuals>();
+  }
+
+  bs::HSceneObject VisualSkeletalAnimation::createAndRegisterSubObject(const bs::String& name)
+  {
+    bs::HSceneObject subSO = bs::SceneObject::create(name);
+
+    bool dontKeepWorldTransform = false;
+
+    subSO->setParent(SO(), dontKeepWorldTransform);
+
+    mSubObjects.push_back(subSO);
+
+    return subSO;
+  }
+
+  void VisualSkeletalAnimation::setupRenderableComponent()
+  {
+    using namespace bs;
+
+    mSubRenderable->setMesh(mMesh->getMesh());
+    mSubRenderable->setMaterials(mMesh->getMaterials());
+  }
+
+  void VisualSkeletalAnimation::setupAnimationComponent()
+  {
+    using namespace bs;
+
+    // We do manual looping
+    // mSubAnimation->setWrapMode(AnimWrapMode::Clamp);
+    // FIXME: Animation Events are broken for clamped animations (in bsf)
+    mSubAnimation->setWrapMode(AnimWrapMode::Loop);
+
+    // Subscribe to animation events
+    mSubAnimation->onEventTriggered.connect([this](auto clip, auto string) {
+      // Call objects actual method
+      this->onAnimationEvent(clip, string);
+    });
+  }
+
+  void VisualSkeletalAnimation::onAnimationEvent(const bs::HAnimationClip& clip, bs::String string)
+  {
+    using namespace bs;
+
+    throwIfNotReadyForRendering();
+
+    bs::String command = string.substr(0, string.find_first_of(':'));
+    bs::String action  = string.substr(command.length() + 1);
+
+    bs::AnimationClipState state;
+    mSubAnimation->getState(clip, state);
+
+    // gDebug().logDebug(bs::StringUtil::format(
+    //     "[VisualSkeletalAnimation] Got animation event: {0}:{1} while playing {2} at {3}",
+    //     command, action, clip->getName(), state.time));
+
+    // gDebug().logDebug("Animation has the following events: ");
+    // for (auto& event : clip->getEvents())
+    // {
+    //   gDebug().logDebug(bs::StringUtil::format(" - {0}: {1}", event.time, event.name));
+    // }
+
+    if (command == "PLAYCLIP")
+    {
+      HAnimationClip clip = findAnimationClip(action);
+
+      if (clip)
+      {
+        playAnimation(clip);
+      }
+      else
+      {
+        gDebug().logWarning("[VisualSkeletalAnimation] Unknown next animation: " + action);
+      }
+    }
+    else
+    {
+      gDebug().logWarning("[VisualSkeletalAnimation] Unknown animation event: " + string);
+    }
+  }
+
+  void VisualSkeletalAnimation::playAnimation(bs::HAnimationClip clip)
+  {
+    using namespace bs;
+
+    throwIfNotReadyForRendering();
+
+    if (clip)
+    {
+      // bs::gDebug().logDebug(clip->getName());
+      mSubAnimation->play(clip);
+    }
+    else
+    {
+      mSubAnimation->stopAll();
+    }
+  }
+
+  void REGoth::VisualSkeletalAnimation::playDefaultIdleAnimation()
+  {
+    auto possibleAnims = {"S_RUN", "S_FISTRUN", "S_S0"};
+
+    for (auto anim : possibleAnims)
+    {
+      bs::HAnimationClip clip = findAnimationClip(anim);
+
+      if (clip)
+      {
+        playAnimation(clip);
+        return;
+      }
+    }
+
+    // No animation found, stop all animations instead
+    playAnimation({});
+  }
+
+  bool VisualSkeletalAnimation::tryPlayTransitionAnimationTo(const bs::String& state)
+  {
+    bs::HAnimationClip clip;
+
+    if (Animation::isTransitionNeeded(state))
+    {
+      bs::String from = getStateFromPlayingAnimation();
+      bs::String to   = Animation::getStateName(state);
+
+      if (from.empty()) return false;
+
+      bs::String transition =
+          Animation::constructTransitionAnimationName(REGoth::Animation::WeaponMode::None, from, to);
+
+      if (transition.empty()) return false;
+
+      clip = findAnimationClip(transition);
+    }
+    else
+    {
+      clip = findAnimationClip(state);
+    }
+
+    if (!clip) return false;
+
+    if (!isAnimationPlaying(clip))
+    {
+      playAnimation(clip);
+    }
+
+    return true;
+  }
+
+  bs::HAnimationClip VisualSkeletalAnimation::findAnimationClip(const bs::String& name) const
+  {
+    using namespace bs;
+
+    bs::String actualName = mModelScript->getName() + "-" + name;
+
+    auto result = mAnimationClips.find(actualName);
+
+    if (result == mAnimationClips.end()) return {};
+
+    return result->second;
+  }
+
+  bool VisualSkeletalAnimation::isAnimationPlaying(bs::HAnimationClip clip) const
+  {
+    throwIfNotReadyForRendering();
+
+    for (bs::UINT32 i = 0; i < mSubAnimation->getNumClips(); i++)
+    {
+      if (mSubAnimation->getClip(i) == clip) return true;
+    }
+
+    return false;
+  }
+
+  bs::String VisualSkeletalAnimation::getPlayingAnimationName() const
+  {
+    throwIfNotReadyForRendering();
+
+    if (!mSubAnimation->isPlaying()) return "";
+    if (!mSubAnimation->getClip(0)) return "";
+
+    bs::String full = mSubAnimation->getClip(0)->getName();
+
+    // Strip the "HUMANS-" part
+    return full.substr(full.find_first_of('-') + 1);
+  }
+
+  bool VisualSkeletalAnimation::isPlayingAnimationInterruptable() const
+  {
+    bs::String name = getPlayingAnimationName();
+
+    return name.find("-T_") == bs::String::npos;
+  }
+
+  bs::String VisualSkeletalAnimation::getStateFromPlayingAnimation() const
+  {
+    return Animation::getStateName(getPlayingAnimationName());
+  }
+
+  bs::Vector3 VisualSkeletalAnimation::resolveFrameRootMotion()
+  {
+    if (!mSubAnimation) return bs::Vector3(bs::BsZero);
+
+    bs::HAnimationClip clipNow = mSubAnimation->getClip(0);
+
+    bs::Vector3 motion = bs::Vector3(bs::BsZero);
+
+    if (mRootMotionLastClip != clipNow)
+    {
+      // Make sure to get the last bits of the last clip too
+      if (mRootMotionLastClip)
+      {
+        bs::AnimationClipState state;
+        mSubAnimation->getState(mRootMotionLastClip, state);
+
+        float then = mRootMotionLastTime;
+        float now  = mRootMotionLastClip->getLength();
+
+        motion += Animation::getRootMotionSince(mRootMotionLastClip, then, now);
+      }
+
+      mRootMotionLastTime = 0.0f;
+      mRootMotionLastClip = clipNow;
+    }
+
+    if (!clipNow)
+    {
+      return motion;
+    }
+
+    bs::AnimationClipState state;
+    mSubAnimation->getState(clipNow, state);
+
+    float then = mRootMotionLastTime;
+    float now  = state.time;
+
+    // fixedUpdate might be called more often than the animation timing is updated
+    // Comparing floats here is intentional, since we don't touch them in the meantime.
+    if (then != now)
+    {
+      motion += Animation::getRootMotionSince(clipNow, then, now);
+
+      // bs::gDebug().logDebug(bs::StringUtil::format("RootMotion {0} -> {1}: {2}", then, now,
+      // bs::toString(motion)));
+    }
+
+    mRootMotionLastTime = now;
+    mRootMotionLastClip = clipNow;
+
+    return motion;
+  }
+
+  void VisualSkeletalAnimation::addDefaultAttachments()
+  {
+    throwIfNotReadyForRendering();
+
+    for (const auto& attachment : mMesh->getNodeAttachments())
+    {
+      mSubNodeVisuals->attachMeshToNode(attachment.first, attachment.second);
+    }
+  }
+
+  bs::RTTITypeBase* VisualSkeletalAnimation::getRTTIStatic()
+  {
+    return RTTI_VisualSkeletalAnimation::instance();
+  }
+
+  bs::RTTITypeBase* VisualSkeletalAnimation::getRTTI() const
+  {
+    return VisualSkeletalAnimation::getRTTIStatic();
+  }
+
+}  // namespace REGoth

--- a/src/components/VisualSkeletalAnimation.cpp
+++ b/src/components/VisualSkeletalAnimation.cpp
@@ -271,6 +271,11 @@ namespace REGoth
     playAnimation({});
   }
 
+  bs::Vector<bs::String> VisualSkeletalAnimation::listPossibleDefaultAnimations() const
+  {
+    return {};
+  }
+
   bool VisualSkeletalAnimation::tryPlayTransitionAnimationTo(const bs::String& state)
   {
     bs::HAnimationClip clip;

--- a/src/components/VisualSkeletalAnimation.hpp
+++ b/src/components/VisualSkeletalAnimation.hpp
@@ -162,6 +162,12 @@ namespace REGoth
 
   protected:
     /**
+     * @return A list of animations to try playing after initialization or
+     *         if no animation is playing.
+     */
+    virtual bs::Vector<bs::String> listPossibleDefaultAnimations() const;
+
+    /**
      * Called when a animation event was triggered
      */
     virtual void onAnimationEvent(const bs::HAnimationClip& clip, bs::String string);

--- a/src/components/VisualSkeletalAnimation.hpp
+++ b/src/components/VisualSkeletalAnimation.hpp
@@ -1,0 +1,271 @@
+/** \file
+ */
+
+#pragma once
+
+#include <BsPrerequisites.h>
+#include <BsZenLib/ZenResources.hpp>
+#include <Scene/BsComponent.h>
+
+namespace REGoth
+{
+  class RTTI_VisualSkeletalAnimation;
+  class NodeVisuals;
+  using HNodeVisuals = bs::GameObjectHandle<NodeVisuals>;
+
+  /**
+   * Component for rendering an object animated using skeletal animation (Player, NPC, Monster).
+   *
+   * This component will take care of loading the correct resources and has
+   * an interface to play animations.
+   *
+   * # Object tree
+   *
+   * Because of the way bsf works, one cannot modify any transforms like scaling
+   * or rotation if root-motion is used on a scene object. Therefore the actual
+   * characters renderable and animation components are put into a sub-object.
+   *
+   * This sub-object will also handle all visual node attachments.
+   *
+   * # Model script files
+   *
+   * In Gothic, similar creatures and characters are described inside a so called
+   * *model script file*. Inside this file, every mesh matching the animation
+   * node tree is listed, along with all possible animations and their properties.
+   *
+   * Therefore, this component needs to know the model script and the mesh
+   * that it should display from that model script.
+   */
+  class VisualSkeletalAnimation : public bs::Component
+  {
+  public:
+    VisualSkeletalAnimation(const bs::HSceneObject& parent);
+
+    /**
+     * Set which model script this component should read the list of possible
+     * meshes and animations from. This **must** be set for the component to work.
+     */
+    void setModelScript(BsZenLib::Res::HModelScriptFile modelScript);
+
+    /**
+     * Set the mesh this component should display. This mesh **must** come from
+     * within the given model script file, otherwise the component won't display
+     * the mesh.
+     */
+    void setMesh(BsZenLib::Res::HMeshWithMaterials mesh);
+
+    /**
+     * Sets up the visual according to the given visual name.
+     *
+     * Throws if that visual does not exist.
+     *
+     * @param  visual  Name of the visual (model-script) to use, e.g. `HUMANS.MDS`.
+     */
+    void setVisual(const bs::String& visual);
+
+    /**
+     * Sets the body mesh.
+     *
+     * Throws if the body mesh is not listed inside the model script.
+     *
+     * @param  bodyMesh  Name of the body mesh to use, e.g. `HUM_BODY_NAKED0`. The
+     *                   file extension must be omitted.
+     */
+    void setBodyMesh(const bs::String& bodyMesh);
+
+    /**
+     * Sets the headmesh for this model.
+     *
+     * @param  head  File of the mesh to use as head, e.g. `HUM_HEAD.MMB`. The file
+     *               extension is not required. If none was given, `.MMB` will be
+     *               assumed.
+     */
+    void setHeadMesh(const bs::String& headmesh, bs::UINT32 headTextureIdx = 0,
+                     bs::UINT32 teethTextureIdx = 0);
+
+    /**
+     * Calculates how far the characters animation has moved since the last
+     * call ot this function via animation.
+     *
+     * @return Delta between the animation postion when this function was called
+     *         the last time and now.
+     */
+    bs::Vector3 resolveFrameRootMotion();
+
+    /**
+     * @return The bounds of the underlaying renderable
+     */
+    bs::Bounds getBounds() const;
+
+    /**
+     * Find the animation clip matching the currently set model script and overlay.
+     * Returns an invalid handle when the was not found.
+     *
+     * @param  name  The UPPERCASE animation name (`S_RUNL`)
+     *
+     * @return Animation clip for the given animation name. Invalid if not found.
+     */
+    bs::HAnimationClip findAnimationClip(const bs::String& name) const;
+
+    /**
+     * Plays the given animation clip.
+     */
+    void playAnimation(bs::HAnimationClip clip);
+
+    /**
+     * Searches for the default idle animation for this character and plays it.
+     *
+     * The idle animation for humans is `S_RUN`. For monsters, that one doesn't exist
+     * since they are always in the *Fist*-Weaponmode. Therefore `S_FISTRUN` is being
+     * played instead.
+     *
+     * This method should be only for for testing, since playing the correct animations
+     * should be handled by other parts of the software.
+     */
+    void playDefaultIdleAnimation();
+
+    /**
+     * Tries to transition to the given animation name.
+     *
+     * @param  Animation to transition to, eg `S_RUNL` or `T_JUMPB`.
+     *
+     * @return true, if the transition was possible.
+     */
+    bool tryPlayTransitionAnimationTo(const bs::String& state);
+
+    /**
+     * @return Whether the given animation is currently playing
+     */
+    bool isAnimationPlaying(bs::HAnimationClip clip) const;
+
+    /**
+     * @return Name of the currently playing animation. Empty string if none.
+     */
+    bs::String getPlayingAnimationName() const;
+
+    /**
+     * @return The current state animations state, eg. `RUNL` for `S_RUNL`.
+     */
+    bs::String getStateFromPlayingAnimation() const;
+
+    /**
+     * Whether the currently playing animation can be interrupted by the user.
+     *
+     * This will return false on animations like jumping backwards or
+     * falling onto the floor when dying.
+     *
+     * If no animation is played, true is returned.
+     *
+     * @return Whether the user can interrupt the currently playing animation.
+     */
+    bool isPlayingAnimationInterruptable() const;
+
+  protected:
+    /**
+     * Called when a animation event was triggered
+     */
+    virtual void onAnimationEvent(const bs::HAnimationClip& clip, bs::String string);
+
+    /**
+     * Access to the current model-script for sub-classes.
+     */
+    BsZenLib::Res::HModelScriptFile modelScript() const
+    {
+      return mModelScript;
+    }
+
+    /**
+     * Access to the currently drawn mesh for sub-classes.
+     */
+    BsZenLib::Res::HMeshWithMaterials mesh() const
+    {
+      return mMesh;
+    }
+
+    /**
+     * Access to attaching something to specific nodes for sub-classes.
+     */
+    HNodeVisuals nodeVisuals() const
+    {
+      return mSubNodeVisuals;
+    }
+
+    /**
+     * Throws if there is no model-script or mesh set or if some initalization step
+     * was missing.
+     */
+    void throwIfNotReadyForRendering() const;
+
+  private:
+    /**
+     * @return Whether the given mesh is registered inside the currently set model script
+     */
+    bool isMeshRegisteredInModelScript(BsZenLib::Res::HMeshWithMaterials mesh);
+
+    /**
+     * Deletes all sub objects created by this component (ie. for rendering)
+     */
+    void deleteObjectSubtree();
+
+    /**
+     * (Re)creates all sub objects needed ie. for rendering.
+     */
+    void buildObjectSubtree();
+
+    /**
+     * Creates the sub object and all components needed on that object.
+     */
+    void createAndRegisterSubComponents();
+
+    /**
+     * Creates a sub-object and adds it to the list of all sub-objects.
+     */
+    bs::HSceneObject createAndRegisterSubObject(const bs::String& name);
+
+    /**
+     * Sets up the empty previously created renderable component.
+     */
+    void setupRenderableComponent();
+
+    /**
+     * Sets up the empty previously create animation component.
+     */
+    void setupAnimationComponent();
+
+    /**
+     * Adds the attachments defined inside the model script to their nodes.
+     */
+    void addDefaultAttachments();
+
+    // Configuration ----------------------------------------------------------
+
+    BsZenLib::Res::HModelScriptFile mModelScript; /**< Model-script of the displayed model */
+    BsZenLib::Res::HMeshWithMaterials mMesh; /**< Currently displayed mesh, from the model script */
+
+    // Object Sub Tree --------------------------------------------------------
+    bs::Vector<bs::HSceneObject> mSubObjects; /**< All created sub-objects by this component */
+
+    bs::HRenderable mSubRenderable; /**< The Renderable created inside a sub object */
+    bs::HAnimation mSubAnimation;   /**< The Animation-Component created inside a sub object */
+    HNodeVisuals mSubNodeVisuals;   /**< The NodeVisuals-Component created inside a sub object */
+
+    // Animation --------------------------------------------------------------
+    bs::Map<bs::String, bs::HAnimationClip> mAnimationClips; /**< Animation names -> clip */
+    bs::HAnimationClip mRootMotionLastClip; /**< Last clip we got the root motion from */
+    float mRootMotionLastTime = 0.0f; /**< Last time the animation was queried for root motion */
+
+    /************************************************************************/
+    /* 								RTTI */
+    /************************************************************************/
+  public:
+    friend RTTI_VisualSkeletalAnimation;
+    static bs::RTTITypeBase* getRTTIStatic();
+    bs::RTTITypeBase* getRTTI() const override;
+
+    // protected:
+  public:  // FIXME: Should be protected, it is only used by RRIT but `friend` doesn't seem to work?!
+    VisualSkeletalAnimation() = default;  // Serialization only
+  };
+
+  using HVisualSkeletalAnimation = bs::GameObjectHandle<VisualSkeletalAnimation>;
+}  // namespace REGoth

--- a/src/components/VisualSkeletalAnimation.hpp
+++ b/src/components/VisualSkeletalAnimation.hpp
@@ -55,33 +55,26 @@ namespace REGoth
     void setMesh(BsZenLib::Res::HMeshWithMaterials mesh);
 
     /**
+     * Assigns the first mesh found in the model script via setMesh().
+     *
+     * Can be used instead of calling setMesh(), for example if you know
+     * the model-script only contains a single mesh (like for interactive objects).
+     * Note that setVisual() automatically uses this.
+     *
+     * Throws if no model script has been assigned before or it it is empty.
+     */
+    void useFirstMeshOfModelScript();
+
+    /**
      * Sets up the visual according to the given visual name.
+     *
+     * Will automatically resolve and set the model script and assign its first mesh.
      *
      * Throws if that visual does not exist.
      *
      * @param  visual  Name of the visual (model-script) to use, e.g. `HUMANS.MDS`.
      */
     void setVisual(const bs::String& visual);
-
-    /**
-     * Sets the body mesh.
-     *
-     * Throws if the body mesh is not listed inside the model script.
-     *
-     * @param  bodyMesh  Name of the body mesh to use, e.g. `HUM_BODY_NAKED0`. The
-     *                   file extension must be omitted.
-     */
-    void setBodyMesh(const bs::String& bodyMesh);
-
-    /**
-     * Sets the headmesh for this model.
-     *
-     * @param  head  File of the mesh to use as head, e.g. `HUM_HEAD.MMB`. The file
-     *               extension is not required. If none was given, `.MMB` will be
-     *               assumed.
-     */
-    void setHeadMesh(const bs::String& headmesh, bs::UINT32 headTextureIdx = 0,
-                     bs::UINT32 teethTextureIdx = 0);
 
     /**
      * Calculates how far the characters animation has moved since the last

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,8 +151,6 @@ int main(int argc, char** argv)
     }
   }
 
-  regoth.saveCachedResourceManifests();
-
   HSceneObject startSO = worldSO->findChild("zCVobStartpoint:zCVob");
 
   Vector3 startPosition = startSO ? startSO->getTransform().getPosition() : Vector3(bs::BsZero);

--- a/src/main_CharacterViewer.cpp
+++ b/src/main_CharacterViewer.cpp
@@ -6,7 +6,6 @@
 #include "Utility/BsTime.h"
 #include "animation/StateNaming.hpp"
 #include "components/VisualCharacter.hpp"
-#include "original-content/VirtualFileSystem.hpp"
 #include <BsZenLib/ImportAnimation.hpp>
 #include <BsZenLib/ImportMorphMesh.hpp>
 #include <BsZenLib/ImportPath.hpp>

--- a/src/main_MobViewer.cpp
+++ b/src/main_MobViewer.cpp
@@ -1,0 +1,56 @@
+#include "BsFPSCamera.h"
+#include "REGothEngine.hpp"
+#include <BsZenLib/ImportSkeletalMesh.hpp>
+#include <Components/BsCCamera.h>
+#include <Scene/BsSceneObject.h>
+#include <components/VisualCharacter.hpp>
+#include <original-content/VirtualFileSystem.hpp>
+
+class REGothMobViewer : public REGoth::REGothEngine
+{
+public:
+  void setupMainCamera() override
+  {
+    REGoth::REGothEngine::setupMainCamera();
+
+    mFPSCamera = mMainCamera->SO()->addComponent<bs::FPSCamera>();
+  }
+
+  void setupScene() override
+  {
+    using namespace REGoth;
+
+    for (auto s : gVirtualFileSystem().listAllFiles())
+    {
+      bs::gDebug().logDebug(s);
+    }
+
+    bs::HSceneObject mobSO = bs::SceneObject::create("Mob");
+
+    HVisualCharacter mobVis = mobSO->addComponent<VisualCharacter>();
+
+    // auto mds = BsZenLib::ImportAndCacheMDS("CHESTBIG_OCCHESTMEDIUM.MDS",
+    //                                        gVirtualFileSystem().getFileIndex());
+
+    // for (auto s : mds->getMeshes())
+    // {
+    //   bs::gDebug().logDebug(s->getName());
+    // }
+
+    mobVis->setVisual("CHESTBIG_OCCHESTMEDIUM.MDS");
+    mobVis->setBodyMesh("CHEST");
+
+    mMainCamera->SO()->setPosition(bs::Vector3(1, 0, 0));
+    mMainCamera->SO()->lookAt(bs::Vector3(0, 0, 0));
+  }
+
+protected:
+  bs::HFPSCamera mFPSCamera;
+};
+
+int main(int argc, char** argv)
+{
+  REGothMobViewer regoth;
+
+  return REGoth::main(regoth, argc, argv);
+}

--- a/src/original-content/VirtualFileSystem.cpp
+++ b/src/original-content/VirtualFileSystem.cpp
@@ -1,6 +1,7 @@
 #include "VirtualFileSystem.hpp"
 #include <Error/BsException.h>
 #include <FileSystem/BsFileSystem.h>
+#include <excepction/Throw.hpp>
 #include <vdfs/fileIndex.h>
 
 using namespace REGoth;
@@ -133,6 +134,24 @@ bool REGoth::VirtualFileSystem::hasFile(const bs::String& file) const
   }
 
   return mInternal->fileIndex.hasFile(file.c_str());
+}
+
+void REGoth::VirtualFileSystem::throwIfFileIsMissing(const bs::String& file,
+                                                     const bs::String& message) const
+{
+  if (!hasFile(file))
+  {
+    if (message.empty())
+    {
+      REGOTH_THROW(
+          InvalidStateException,
+          bs::StringUtil::format("Expected file {0} inside VDFS, but it could not be found!", file));
+    }
+    else
+    {
+      REGOTH_THROW(InvalidStateException, message);
+    }
+  }
 }
 
 bool REGoth::VirtualFileSystem::hasFoundGameFiles() const

--- a/src/original-content/VirtualFileSystem.cpp
+++ b/src/original-content/VirtualFileSystem.cpp
@@ -1,5 +1,4 @@
 #include "VirtualFileSystem.hpp"
-#include <Error/BsException.h>
 #include <FileSystem/BsFileSystem.h>
 #include <excepction/Throw.hpp>
 #include <vdfs/fileIndex.h>
@@ -43,13 +42,11 @@ void VirtualFileSystem::setPathToEngineExecutable(const bs::String& argv0)
 
 void VirtualFileSystem::mountDirectory(const bs::Path& path)
 {
-  using namespace bs;
-
   throwOnMissingInternalState();
 
   if (mInternal->isFinalized)
   {
-    BS_EXCEPT(InvalidStateException, "Cannot mount directories on finalized file index.");
+    REGOTH_THROW(InvalidStateException, "Cannot mount directories on finalized file index.");
   }
 
   bs::gDebug().logDebug("[VDFS] Mounting directory: " + path.toString() + " (recursive):");
@@ -74,13 +71,11 @@ void VirtualFileSystem::mountDirectory(const bs::Path& path)
 
 bool VirtualFileSystem::loadPackage(const bs::Path& package)
 {
-  using namespace bs;
-
   throwOnMissingInternalState();
 
   if (mInternal->isFinalized)
   {
-    BS_EXCEPT(InvalidStateException, "Cannot load packages on finalized file index.");
+    REGOTH_THROW(InvalidStateException, "Cannot load packages on finalized file index.");
   }
 
   return mInternal->fileIndex.loadVDF(package.toString().c_str());
@@ -101,8 +96,6 @@ bs::Vector<bs::String> VirtualFileSystem::listAllFiles()
 
 bs::Vector<bs::UINT8> VirtualFileSystem::readFile(const bs::String& file) const
 {
-  using namespace bs;
-
   throwOnMissingInternalState();
 
   if (!mInternal->isFinalized)
@@ -112,7 +105,7 @@ bs::Vector<bs::UINT8> VirtualFileSystem::readFile(const bs::String& file) const
 
   if (!mInternal->isReadyToReadFiles())
   {
-    BS_EXCEPT(InvalidStateException, "VDFS is not ready to read files yet.");
+    REGOTH_THROW(InvalidStateException, "VDFS is not ready to read files yet.");
   }
 
   std::vector<uint8_t> stlData;
@@ -125,12 +118,10 @@ bs::Vector<bs::UINT8> VirtualFileSystem::readFile(const bs::String& file) const
 
 bool REGoth::VirtualFileSystem::hasFile(const bs::String& file) const
 {
-  using namespace bs;
-
   if (!mInternal)
   {
-    BS_EXCEPT(InvalidStateException,
-              "VDFS internal state not available, call setPathToEngineExecutable()");
+    REGOTH_THROW(InvalidStateException,
+                 "VDFS internal state not available, call setPathToEngineExecutable()");
   }
 
   return mInternal->fileIndex.hasFile(file.c_str());
@@ -175,12 +166,10 @@ const VDFS::FileIndex& VirtualFileSystem::getFileIndex()
 
 void VirtualFileSystem::throwOnMissingInternalState() const
 {
-  using namespace bs;
-
   if (!mInternal)
   {
-    BS_EXCEPT(InvalidStateException,
-              "VDFS internal state not available, call setPathToEngineExecutable()");
+    REGOTH_THROW(InvalidStateException,
+                 "VDFS internal state not available, call setPathToEngineExecutable()");
   }
 }
 

--- a/src/original-content/VirtualFileSystem.hpp
+++ b/src/original-content/VirtualFileSystem.hpp
@@ -128,6 +128,13 @@ namespace REGoth
      */
     bool hasFile(const bs::String& file) const;
 
+    /**
+     * Throws if the given file is missing in the file index.
+     *
+     * @param  file     File to search for, see hasFile().
+     * @param  message  (Optional) Message to append to the exception text.
+     */
+    void throwIfFileIsMissing(const bs::String& file, const bs::String& message = "") const;
 
     /**
      * @return Whether (at least some) of the game files were found in the given data directory

--- a/src/world/internals/ImportSingleVob.cpp
+++ b/src/world/internals/ImportSingleVob.cpp
@@ -1,5 +1,6 @@
 #include "ImportSingleVob.hpp"
 #include <Components/BsCLight.h>
+#include <components/Visual.hpp>
 #include <Math/BsMatrix4.h>
 #include <Scene/BsSceneObject.h>
 #include <components/StartSpot.hpp>
@@ -28,6 +29,10 @@ namespace REGoth
   static bs::HSceneObject import_oCItem(const ZenLoad::zCVobData& vob);
   static bs::HSceneObject import_zCVobSound(const ZenLoad::zCVobData& vob);
   static bs::HSceneObject import_zCVobAnimate(const ZenLoad::zCVobData& vob);
+  static bs::HSceneObject import_oCMobInter(const ZenLoad::zCVobData& vob);
+  static bs::HSceneObject import_oCMobContainer(const ZenLoad::zCVobData& vob);
+  static bs::HSceneObject import_oCMobBed(const ZenLoad::zCVobData& vob);
+  static bs::HSceneObject import_oCMobDoor(const ZenLoad::zCVobData& vob);
   static void addVisualTo(bs::HSceneObject sceneObject, const bs::String& visualName);
 
   bs::HSceneObject World::importSingleVob(const ZenLoad::zCVobData& vob)
@@ -59,6 +64,22 @@ namespace REGoth
     else if (vob.objectClass == "zCVobAnimate:zCVob")
     {
       return import_zCVobAnimate(vob);
+    }
+    else if (vob.objectClass == "oCMobInter:oCMOB:zCVob")
+    {
+      return import_oCMobInter(vob);
+    }
+    else if (vob.objectClass == "oCMobContainer:oCMobInter:oCMOB:zCVob")
+    {
+      return import_oCMobContainer(vob);
+    }
+    else if (vob.objectClass == "oCMobBed:oCMobInter:oCMOB:zCVob")
+    {
+      return import_oCMobBed(vob);
+    }
+    else if (vob.objectClass == "oCMobDoor:oCMobInter:oCMOB:zCVob")
+    {
+      return import_oCMobDoor(vob);
     }
     else
     {
@@ -171,18 +192,51 @@ namespace REGoth
     return so;
   }
 
+  static bs::HSceneObject import_oCMobInter(const ZenLoad::zCVobData& vob)
+  {
+    bs::HSceneObject so = import_zCVob(vob);
+
+    // TODO: Implement
+
+    return so;
+  }
+
+  static bs::HSceneObject import_oCMobContainer(const ZenLoad::zCVobData& vob)
+  {
+    bs::HSceneObject so = import_zCVob(vob);
+
+    // TODO: Implement
+
+    return so;
+  }
+
+  static bs::HSceneObject import_oCMobBed(const ZenLoad::zCVobData& vob)
+  {
+    bs::HSceneObject so = import_zCVob(vob);
+
+    // TODO: Implement
+
+    return so;
+  }
+
+  static bs::HSceneObject import_oCMobDoor(const ZenLoad::zCVobData& vob)
+  {
+    bs::HSceneObject so = import_zCVob(vob);
+
+    // TODO: Implement
+
+    return so;
+  }
+
   /**
    * Adds the given visual to the scene object. If that's not possible
    * nothing will be added.
    */
   static void addVisualTo(bs::HSceneObject sceneObject, const bs::String& visualName)
   {
-    if (visualName.find(".3DS") != bs::String::npos)
-    {
-      HVisualStaticMesh visual = sceneObject->addComponent<VisualStaticMesh>();
-      visual->setMesh(visualName);
-    }
-    else
+    bool hasAdded = Visual::addToSceneObject(sceneObject, visualName);
+
+    if (!hasAdded)
     {
       bs::gDebug().logWarning("[ImportSingleVob] Unsupported visual: " + visualName);
     }


### PR DESCRIPTION
This PR adds the `VisualInteractiveObject` for use with MOBs. It also refactors the `VisualCharacter` so that much code could be put into a generic `VisualSkeletalAnimation` which allows much code to be shared between VisualInteractiveObject` and VisualCharacter`.

It also adds loading of interactive objects from Zen for some simple objects. However, the objects orientations might not be correct. This is because bs:f does not seem to move objects attached to bones to their correct location when no animation is playing...