### PR TITLE
Draw waypoint names above waypoints

### DIFF
--- a/src/components/Waynet.cpp
+++ b/src/components/Waynet.cpp
@@ -1,6 +1,7 @@
 #include "Waynet.hpp"
 #include <Debug/BsDebugDraw.h>
 #include <Scene/BsSceneObject.h>
+#include <components/AnchoredTextLabels.h>
 #include <components/Waypoint.hpp>
 
 namespace REGoth
@@ -24,16 +25,19 @@ namespace REGoth
     mWaypoints.push_back(waypoint);
   }
 
-  void Waynet::debugDraw()
+  void Waynet::debugDraw(const REGoth::HAnchoredTextLabels& textLabels)
   {
     bs::DebugDraw::instance().setColor(bs::Color::Red);
 
     for (HWaypoint from : allWaypoints())
     {
+      const bs::Transform& fromTransform = from->SO()->getTransform();
+
+      textLabels->addLabel(fromTransform.pos() + fromTransform.getUp() * 0.5f,
+                           bs::HString(from->SO()->getName()));
       for (HWaypoint to : from->allPaths())
       {
-        bs::DebugDraw::instance().drawLine(from->SO()->getTransform().pos(),
-                                           to->SO()->getTransform().pos());
+        bs::DebugDraw::instance().drawLine(fromTransform.pos(), to->SO()->getTransform().pos());
       }
     }
   }

--- a/src/components/Waynet.hpp
+++ b/src/components/Waynet.hpp
@@ -10,6 +10,9 @@ namespace REGoth
   class Waypoint;
   using HWaypoint = bs::GameObjectHandle<Waypoint>;
 
+  class AnchoredTextLabels;
+  using HAnchoredTextLabels = bs::GameObjectHandle<AnchoredTextLabels>;
+
   /**
    * Waynet of a world.
    *
@@ -65,7 +68,7 @@ namespace REGoth
     /**
      * Draws the waynet as lines.
      */
-    void debugDraw();
+    void debugDraw(const REGoth::HAnchoredTextLabels& textLabels);
 
   private:
     bs::Vector<HWaypoint> mWaypoints;

--- a/src/main_WaynetTest.cpp
+++ b/src/main_WaynetTest.cpp
@@ -1,3 +1,5 @@
+#include "components/AnchoredTextLabels.h"
+#include <GUI/BsCGUIWidget.h>
 #include "BsFPSCamera.h"
 #include "REGothEngine.hpp"
 #include <Components/BsCCamera.h>
@@ -19,6 +21,13 @@ public:
     REGoth::REGothEngine::setupMainCamera();
 
     mMainCamera->SO()->addComponent<bs::FPSCamera>();
+
+    auto guiSO = bs::SceneObject::create("GUI");
+    auto guiWidget = guiSO->addComponent<bs::CGUIWidget>(mMainCamera);
+
+    auto debugOverlaySO = bs::SceneObject::create("DebugOverlay");
+    mTextLabels         = debugOverlaySO->addComponent<REGoth::AnchoredTextLabels>(guiWidget);
+    mTextLabels->setMaximumDistance(50.f);
   }
 
   void setupScene() override
@@ -43,10 +52,11 @@ public:
       REGOTH_THROW(InvalidStateException, "Waynet does not have Waynet component?");
     }
 
-    waynet->debugDraw();
+    waynet->debugDraw(mTextLabels);
   }
 
 protected:
+  REGoth::HAnchoredTextLabels mTextLabels;
 };
 
 int main(int argc, char** argv)


### PR DESCRIPTION
This PR adds drawing of `Waypoint` names to the debug draw of the `Waynet`. A name appears as text label above their corresponding waypoint in 3d world space.