### PR TITLE
Feature/gameclock

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,7 @@ add_library(REGothEngine
   RTTI/RTTI_NodeVisuals.hpp
   RTTI/RTTI_Waynet.hpp
   RTTI/RTTI_Waypoint.hpp
+  RTTI/RTTI_GameClock.hpp
   )
 
 target_link_libraries(REGothEngine PUBLIC bsf BsZenLib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,8 @@ add_library(REGothEngine
   components/Waynet.cpp
   components/CharacterKeyboardInput.hpp
   components/CharacterKeyboardInput.cpp
+  components/GameClock.hpp
+  components/GameClock.cpp
   exception/Throw.hpp
   animation/StateNaming.hpp
   animation/StateNaming.cpp

--- a/src/RTTI/RTTI_GameClock.hpp
+++ b/src/RTTI/RTTI_GameClock.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "RTTI_TypeIDs.hpp"
+#include <BsCorePrerequisites.h>
+#include <Private/RTTI/BsGameObjectRTTI.h>  // Says private, but bs:f uses this too in their RTTIs
+#include <Reflection/BsRTTIType.h>
+#include <components/GameClock.hpp>
+
+namespace REGoth
+{
+  class RTTI_GameClock
+      : public bs::RTTIType<GameClock, bs::Component, RTTI_GameClock>
+  {
+    BS_BEGIN_RTTI_MEMBERS
+    // TODO: Fill RTTI Members
+    BS_END_RTTI_MEMBERS
+
+  public:
+    RTTI_GameClock()
+    {
+    }
+
+    bs::SPtr<bs::IReflectable> newRTTIObject() override
+    {
+      return bs::GameObjectRTTI::createGameObject<GameClock>();
+    }
+
+    const bs::String& getRTTIName() override
+    {
+      static bs::String name = "GameClock";
+      return name;
+    }
+
+    bs::UINT32 getRTTIId() override
+    {
+      return TID_REGOTH_GameClock;
+    }
+  };
+
+}  // namespace REGoth

--- a/src/RTTI/RTTI_GameClock.hpp
+++ b/src/RTTI/RTTI_GameClock.hpp
@@ -21,21 +21,7 @@ namespace REGoth
     {
     }
 
-    bs::SPtr<bs::IReflectable> newRTTIObject() override
-    {
-      return bs::GameObjectRTTI::createGameObject<GameClock>();
-    }
-
-    const bs::String& getRTTIName() override
-    {
-      static bs::String name = "GameClock";
-      return name;
-    }
-
-    bs::UINT32 getRTTIId() override
-    {
-      return TID_REGOTH_GameClock;
-    }
+    REGOTH_IMPLEMENT_RTTI_CLASS_FOR_COMPONENT(GameClock)
   };
 
 }  // namespace REGoth

--- a/src/RTTI/RTTI_GameClock.hpp
+++ b/src/RTTI/RTTI_GameClock.hpp
@@ -13,7 +13,7 @@ namespace REGoth
   {
     BS_BEGIN_RTTI_MEMBERS
       BS_RTTI_MEMBER_PLAIN(mElapsedSeconds, 0)
-      BS_RTTI_MEMBER_PLAIN(mElapsedIngameSeconds, 0)
+      BS_RTTI_MEMBER_PLAIN(mElapsedIngameSeconds, 1)
     BS_END_RTTI_MEMBERS
 
   public:

--- a/src/RTTI/RTTI_GameClock.hpp
+++ b/src/RTTI/RTTI_GameClock.hpp
@@ -12,7 +12,8 @@ namespace REGoth
       : public bs::RTTIType<GameClock, bs::Component, RTTI_GameClock>
   {
     BS_BEGIN_RTTI_MEMBERS
-    // TODO: Fill RTTI Members
+      BS_RTTI_MEMBER_PLAIN(mElapsedSeconds, 0)
+      BS_RTTI_MEMBER_PLAIN(mElapsedIngameSeconds, 0)
     BS_END_RTTI_MEMBERS
 
   public:

--- a/src/RTTI/RTTI_GameWorld.hpp
+++ b/src/RTTI/RTTI_GameWorld.hpp
@@ -13,6 +13,7 @@ namespace REGoth
     BS_RTTI_MEMBER_REFL(mWaynet, 1)
     BS_RTTI_MEMBER_REFLPTR(mScriptVM, 2)
     BS_RTTI_MEMBER_PLAIN(mIsInitialized, 3)
+    BS_RTTI_MEMBER_REFL(mGameClock, 4)
     BS_END_RTTI_MEMBERS
 
     public:

--- a/src/RTTI/RTTI_TypeIDs.hpp
+++ b/src/RTTI/RTTI_TypeIDs.hpp
@@ -42,5 +42,6 @@ namespace REGoth
     TID_REGOTH_ScriptSymbolUnsupported      = 600034,
     TID_REGOTH_ScriptClassTemplates         = 600035,
     TID_REGOTH_ScriptObjectMapping          = 600036,
+	TID_REGOTH_GameClock					= 600037,
   };
 }  // namespace REGoth

--- a/src/RTTI/RTTI_TypeIDs.hpp
+++ b/src/RTTI/RTTI_TypeIDs.hpp
@@ -42,6 +42,6 @@ namespace REGoth
     TID_REGOTH_ScriptSymbolUnsupported      = 600034,
     TID_REGOTH_ScriptClassTemplates         = 600035,
     TID_REGOTH_ScriptObjectMapping          = 600036,
-	TID_REGOTH_GameClock					= 600037,
+    TID_REGOTH_GameClock                    = 600037,
   };
 }  // namespace REGoth

--- a/src/components/GameClock.cpp
+++ b/src/components/GameClock.cpp
@@ -94,13 +94,5 @@ namespace REGoth
     //       SpawnManager.SpawnImmediately(ResetSpawnTime)
   }
 
-  bs::RTTITypeBase* GameClock::getRTTIStatic()
-  {
-    return RTTI_GameClock::instance();
-  }
-
-  bs::RTTITypeBase* GameClock::getRTTI() const
-  {
-    return GameClock::getRTTIStatic();
-  }
+  REGOTH_DEFINE_RTTI(GameClock)
 }  // namespace REGoth

--- a/src/components/GameClock.cpp
+++ b/src/components/GameClock.cpp
@@ -79,19 +79,31 @@ namespace REGoth
   {
     // TODO: Negative input parameters are supported for hour, but what about negative values that result in negative remaining hours?
     //       Do we need to handle negative Minutes at all?
-    float elapsedDaysInSeconds = getDay() * SECONDS_IN_A_DAY;
     bs::INT32 daysToAdvance    = hour / 24;
-
+    bs::INT32 day = getDay()+daysToAdvance;
     hour = hour % 24;
     min  = min % 60;
 
-    mElapsedIngameSeconds = elapsedDaysInSeconds + (daysToAdvance*SECONDS_IN_A_DAY + hour*SECONDS_IN_AN_HOUR + min*SECONDS_IN_A_MINUTE);
+    setTime((bs::UINT32)day, (bs::UINT8)hour, (bs::UINT8)min);
 
     // TODO: According to https://forum.worldofplayers.de/forum/threads/396326-Tipp-Tageweise-springen-%28auch-zur%C3%BCck%29?p=6231841&viewfull=1#post6231841
     //       if this shall be the Wld_setTime external, it also needs to implement these three functions here
     //       RoutineManager.SetDailyRoutinePos(RoutinesOnly)
     //       Game.SetObjectRoutineTimeChange(GameHour, GameMinute, Hour, Minute)
     //       SpawnManager.SpawnImmediately(ResetSpawnTime)
+  }
+
+  void GameClock::setDay(bs::UINT32 day)
+  {
+    bs::UINT8 hour = (bs::UINT8)getHour();
+    bs::UINT8 min = (bs::UINT8)getMinute();
+
+    setTime(day, hour, min);
+  }
+
+  void GameClock::setTime(bs::UINT32 day, bs::UINT8 hour, bs::UINT8 min)
+  {
+    mElapsedIngameSeconds = day*SECONDS_IN_A_DAY + hour*SECONDS_IN_AN_HOUR + min*SECONDS_IN_A_MINUTE;
   }
 
   REGOTH_DEFINE_RTTI(GameClock)

--- a/src/components/GameClock.cpp
+++ b/src/components/GameClock.cpp
@@ -1,0 +1,73 @@
+#include "GameClock.hpp"
+#include <RTTI/RTTI_GameClock.hpp>
+#include <Scene/BsSceneObject.h>
+#include <exception/Throw.hpp>
+#include <Math/BsMath.h>
+
+namespace REGoth
+{
+  constexpr float SECONDS_IN_A_MINUTE = 60;
+  constexpr float SECONDS_IN_AN_HOUR  = 60 * SECONDS_IN_A_MINUTE;
+  constexpr float SECONDS_IN_A_DAY    = 24 * SECONDS_IN_AN_HOUR;
+  constexpr float CLOCK_SPEED_FACTOR  = 14.5;
+
+  GameClock::GameClock(const bs::HSceneObject& parent)
+    : bs::Component(parent)
+  { }
+
+  void GameClock::update()
+  {
+    float delta = bs::gTime().getFrameDelta();
+
+    mElapsedSeconds       += delta;
+    mElapsedIngameSeconds += delta * CLOCK_SPEED_FACTOR;
+  }
+
+  bs::UINT32 GameClock::getDay() const
+  {
+    return bs::Math::floorToPosInt(mElapsedIngameSeconds/SECONDS_IN_A_DAY);
+  }
+
+  bs::UINT8 GameClock::getHour() const
+  {
+    float elapsedSecondsOfDay = mElapsedIngameSeconds-(getDay()*SECONDS_IN_A_DAY);
+    
+    return bs::Math::floorToPosInt(elapsedSecondsOfDay/SECONDS_IN_AN_HOUR);
+  }
+
+  bs::UINT8 GameClock::getMinute() const
+  {
+    float elapsedSecondsOfHour = mElapsedIngameSeconds-(getDay()*SECONDS_IN_A_DAY)-(getHour()*SECONDS_IN_AN_HOUR);
+
+    return bs::Math::floorToPosInt(elapsedSecondsOfHour/SECONDS_IN_A_MINUTE);
+  }
+
+  bool GameClock::isTime(bs::UINT8 hour1, bs::UINT8 min1, bs::UINT8 hour2, bs::UINT8 min2) const
+  {
+    float elapsedSecondsOfDay = mElapsedIngameSeconds-(getDay()*SECONDS_IN_A_DAY);
+    float lowerElapsedSecondsOfDay = ((hour1*SECONDS_IN_AN_HOUR)+(min1*SECONDS_IN_A_MINUTE))*CLOCK_SPEED_FACTOR;
+    float upperElapsedSecondsOfDay = ((hour2*SECONDS_IN_AN_HOUR)+(min2*SECONDS_IN_A_MINUTE))*CLOCK_SPEED_FACTOR;
+
+    // TODO: Not sure if Gothic allows the order of the input times to be reversed
+    return (elapsedSecondsOfDay>lowerElapsedSecondsOfDay && elapsedSecondsOfDay<upperElapsedSecondsOfDay);
+  }
+
+  void GameClock::setTime(bs::UINT8 hour, bs::UINT8 min)
+  {
+    bs::INT8 minutesToAdvance = (min%60)-getMinute();
+    bs::INT8 hoursToAdvance = (hour%24)-getHour();
+    bs::UINT8 daysToAdvance = hour/24;
+
+    mElapsedIngameSeconds += ((daysToAdvance*SECONDS_IN_A_DAY)+(hoursToAdvance*SECONDS_IN_AN_HOUR)+(minutesToAdvance*SECONDS_IN_A_MINUTE))*CLOCK_SPEED_FACTOR;
+  }
+
+  bs::RTTITypeBase* GameClock::getRTTIStatic()
+  {
+    return RTTI_GameClock::instance();
+  }
+
+  bs::RTTITypeBase* GameClock::getRTTI() const
+  {
+    return GameClock::getRTTIStatic();
+  }
+}  // namespace REGoth

--- a/src/components/GameClock.cpp
+++ b/src/components/GameClock.cpp
@@ -14,9 +14,9 @@ namespace REGoth
     : bs::Component(parent)
   { }
 
-  void GameClock::update()
+  void GameClock::fixedUpdate()
   {
-    float delta = bs::gTime().getFrameDelta();
+    float delta = bs::gTime().getFixedFrameDelta();
 
     mElapsedSeconds       += delta;
     mElapsedIngameSeconds += delta * CLOCK_SPEED_FACTOR;
@@ -27,14 +27,14 @@ namespace REGoth
     return bs::Math::floorToPosInt(mElapsedIngameSeconds / SECONDS_IN_A_DAY);
   }
 
-  bs::UINT8 GameClock::getHour() const
+  bs::INT32 GameClock::getHour() const
   {
     float elapsedSecondsOfDay = mElapsedIngameSeconds - (getDay() * SECONDS_IN_A_DAY);
     
     return bs::Math::floorToPosInt(elapsedSecondsOfDay / SECONDS_IN_AN_HOUR);
   }
 
-  bs::UINT8 GameClock::getMinute() const
+  bs::INT32 GameClock::getMinute() const
   {
     float elapsedSecondsOfHour = mElapsedIngameSeconds - (getDay() * SECONDS_IN_A_DAY) - (getHour() * SECONDS_IN_AN_HOUR);
 

--- a/src/components/GameClock.hpp
+++ b/src/components/GameClock.hpp
@@ -2,6 +2,7 @@
 #include <BsPrerequisites.h>
 #include <Scene/BsComponent.h>
 #include <Utility/BsTime.h>
+#include <RTTI/RTTIUtil.hpp>
 
 namespace REGoth
 {
@@ -73,9 +74,7 @@ namespace REGoth
   /* RTTI                                                                 */
   /************************************************************************/
   public:
-    friend class RTTI_GameClock;
-    static bs::RTTITypeBase* getRTTIStatic();
-    bs::RTTITypeBase* getRTTI() const override;
+    REGOTH_DECLARE_RTTI(GameClock)
 
   // protected:
   public:  // FIXME: Should be protected, it is only used by RTTI but friend doesn't seem to work?!

--- a/src/components/GameClock.hpp
+++ b/src/components/GameClock.hpp
@@ -21,48 +21,49 @@ namespace REGoth
     void update() override;
 
     /**
-     * @return Current ingame clock day.
+     * @return Current ingame day.
      */
-    bs::UINT32 getDay() const;
+    bs::INT32 getDay() const;
 
     /**
-     * @return Current ingame clock hour.
+     * @return Current hour of time of day (hh:mm).
      */
     bs::UINT8 getHour() const;
 
     /**
-     * @return Current ingame clock minute.
+     * @return Current Minute of time of day (hh:mm).
      */
     bs::UINT8 getMinute() const;
 
     /**
-     * @return  Whether the current ingame clock (hh::mm) is between the two given values.
+     * @return  Whether the current ingame time of day (hh::mm) is between the two given times of day.
+     *
+     * @note    The first time of day can be after the second time of day.
      *
      * @param   hour1
-     *              Lower limit of elapsed ingame time in hours to check against.
-     *              Is added to param min1.
+     *              Hour of the first time of day (\p hour1 : \p min1 ) to check against.
      * @param   min1
-     *              Lower limit of elapsed ingame time in minutes to check against.
-     *              Is added to parameter hour1.
+     *              Minute of the first time of day (\p hour1 : \p min1 ) to check against.
      * @param   hour2
-     *              Upper limit of elapsed ingame time in hours to check against.
-     *              Is added to param min2.     
+     *              Hour of the second time of day (\p hour2 : \p min2 ) to check against.
      * @param   min2
-     *              Upper limit of elapsed ingame time in minutes. to check against.
-     *              Is added to parameter hour2.
+     *              Minute of the second time of day (\p hour2 : \p min2 ) to check against.
      */
-    bool isTime(bs::UINT8 hour1, bs::UINT8 min1, bs::UINT8 hour2, bs::UINT8 min2) const;
+    bool isTime(bs::INT32 hour1, bs::INT32 min1, bs::INT32 hour2, bs::INT32 min2) const;
     
     /**
-     * Sets the ingame clock to the given hh:mm.
-     * Skips to the next occurence of the given hh::mm advancing the day.
+     * Sets the ingame clock (hh:mm) to the given time in hour and minute.
      * 
+     * @note   Values for \p hour can be over 23 to advance days too.
+     *         Calling setTime(24+15, 0) sets the clock to 15:00 and advances one day.
+     *
      * @param  hour
-     *             Can be a value over 23 to advance to the next day.
+     *             Accepts any value (int32), but will use \p hour%24 internally.
+     *             Can also advance days - see note.
      * @param  min
-     *             Minute.
+     *             Accepts any value (int32), but will use \p min%60 internally.
      */
-    void setTime(bs::UINT8 hour, bs::UINT8 min);
+    void setTime(bs::INT32 hour, bs::INT32 min);
 
   private:
     float mElapsedSeconds       = 0.0;

--- a/src/components/GameClock.hpp
+++ b/src/components/GameClock.hpp
@@ -1,0 +1,85 @@
+#pragma once
+#include <BsPrerequisites.h>
+#include <Scene/BsComponent.h>
+#include <Utility/BsTime.h>
+
+namespace REGoth
+{
+  /**
+   * Component that handles play and ingame time.
+   * Offers externals for timespecific Wld_* functions.
+   * Shall be instantiated with the World.
+   */
+  class GameClock : public bs::Component
+  {
+  public:
+    GameClock(const bs::HSceneObject& parent);
+
+    /**
+     * Triggered once per frame. Updates elapsedSeconds for play and ingame time.
+     */
+    void update() override;
+
+    /**
+     * @return Current ingame clock day.
+     */
+    bs::UINT32 getDay() const;
+
+    /**
+     * @return Current ingame clock hour.
+     */
+    bs::UINT8 getHour() const;
+
+    /**
+     * @return Current ingame clock minute.
+     */
+    bs::UINT8 getMinute() const;
+
+    /**
+     * @return  Whether the current ingame clock (hh::mm) is between the two given values.
+     *
+     * @param   hour1
+     *              Lower limit of elapsed ingame time in hours to check against.
+     *              Is added to param min1.
+     * @param   min1
+     *              Lower limit of elapsed ingame time in minutes to check against.
+     *              Is added to parameter hour1.
+     * @param   hour2
+     *              Upper limit of elapsed ingame time in hours to check against.
+     *              Is added to param min2.     
+     * @param   min2
+     *              Upper limit of elapsed ingame time in minutes. to check against.
+     *              Is added to parameter hour2.
+     */
+    bool isTime(bs::UINT8 hour1, bs::UINT8 min1, bs::UINT8 hour2, bs::UINT8 min2) const;
+    
+    /**
+     * Sets the ingame clock to the given hh:mm.
+     * Skips to the next occurence of the given hh::mm advancing the day.
+     * 
+     * @param  hour
+     *             Can be a value over 23 to advance to the next day.
+     * @param  min
+     *             Minute.
+     */
+    void setTime(bs::UINT8 hour, bs::UINT8 min);
+
+  private:
+    float mElapsedSeconds       = 0.0;
+    float mElapsedIngameSeconds = 0.0;
+
+  /************************************************************************/
+  /* RTTI                                                                 */
+  /************************************************************************/
+  public:
+    friend class RTTI_CharacterKeyboardInput;
+    static bs::RTTITypeBase* getRTTIStatic();
+    bs::RTTITypeBase* getRTTI() const override;
+
+  // protected:
+  public:  // FIXME: Should be protected, it is only used by RTTI but friend doesn't seem to work?!
+    GameClock() = default;  // Serialization only
+  };
+
+  using HGameClock = bs::GameObjectHandle<GameClock>;
+}  // namespace REGoth

--- a/src/components/GameClock.hpp
+++ b/src/components/GameClock.hpp
@@ -66,9 +66,13 @@ namespace REGoth
      */
     void setTime(bs::INT32 hour, bs::INT32 min);
 
+    void setDay(bs::UINT32 day);
+
   private:
     float mElapsedSeconds       = 0.0;
     float mElapsedIngameSeconds = 0.0;
+
+    void setTime(bs::UINT32 day, bs::UINT8 hour, bs::UINT8 min);
 
   /************************************************************************/
   /* RTTI                                                                 */

--- a/src/components/GameClock.hpp
+++ b/src/components/GameClock.hpp
@@ -16,9 +16,9 @@ namespace REGoth
     GameClock(const bs::HSceneObject& parent);
 
     /**
-     * Triggered once per frame. Updates elapsedSeconds for play and ingame time.
+     * Triggered once every fixed time step. Updates elapsedSeconds for play and ingame time.
      */
-    void update() override;
+    void fixedUpdate() override;
 
     /**
      * @return Current ingame day.
@@ -28,12 +28,12 @@ namespace REGoth
     /**
      * @return Current hour of time of day (hh:mm).
      */
-    bs::UINT8 getHour() const;
+    bs::INT32 getHour() const;
 
     /**
      * @return Current Minute of time of day (hh:mm).
      */
-    bs::UINT8 getMinute() const;
+    bs::INT32 getMinute() const;
 
     /**
      * @return  Whether the current ingame time of day (hh::mm) is between the two given times of day.
@@ -73,7 +73,7 @@ namespace REGoth
   /* RTTI                                                                 */
   /************************************************************************/
   public:
-    friend class RTTI_CharacterKeyboardInput;
+    friend class RTTI_GameClock;
     static bs::RTTITypeBase* getRTTIStatic();
     bs::RTTITypeBase* getRTTI() const override;
 

--- a/src/components/GameClock.hpp
+++ b/src/components/GameClock.hpp
@@ -69,8 +69,8 @@ namespace REGoth
     void setDay(bs::UINT32 day);
 
   private:
-    float mElapsedSeconds       = 0.0;
-    float mElapsedIngameSeconds = 0.0;
+    float mElapsedSeconds       = 0.0f;
+    float mElapsedIngameSeconds = 0.0f;
 
     void setTime(bs::UINT32 day, bs::UINT8 hour, bs::UINT8 min);
 

--- a/src/components/GameWorld.cpp
+++ b/src/components/GameWorld.cpp
@@ -58,7 +58,9 @@ namespace REGoth
 
     onImportedZEN();
 
-    mGameClock = SO()->addComponent<GameClock>();
+    bs::HSceneObject gameclockSO = bs::SceneObject::create("GameClock");
+    gameclockSO->setParent(SO());
+    mGameClock = gameclockSO->addComponent<GameClock>();
 
     mIsInitialized = true;
   }

--- a/src/components/GameWorld.cpp
+++ b/src/components/GameWorld.cpp
@@ -9,6 +9,7 @@
 #include <components/Item.hpp>
 #include <components/VisualCharacter.hpp>
 #include <components/Waynet.hpp>
+#include <components/GameClock.hpp>
 #include <daedalus/DATFile.h>
 #include <exception/Throw.hpp>
 #include <original-content/VirtualFileSystem.hpp>
@@ -56,6 +57,8 @@ namespace REGoth
     }
 
     onImportedZEN();
+
+    mGameClock = SO()->addComponent<GameClock>();
 
     mIsInitialized = true;
   }

--- a/src/components/GameWorld.cpp
+++ b/src/components/GameWorld.cpp
@@ -58,9 +58,7 @@ namespace REGoth
 
     onImportedZEN();
 
-    bs::HSceneObject gameclockSO = bs::SceneObject::create("GameClock");
-    gameclockSO->setParent(SO());
-    mGameClock = gameclockSO->addComponent<GameClock>();
+    mGameClock = SO()->addComponent<GameClock>();
 
     mIsInitialized = true;
   }

--- a/src/components/GameWorld.hpp
+++ b/src/components/GameWorld.hpp
@@ -11,6 +11,9 @@ namespace REGoth
   class Waynet;
   using HWaynet = bs::GameObjectHandle<Waynet>;
 
+  class GameClock;
+  using HGameClock = bs::GameObjectHandle<GameClock>;
+
   class Character;
   using HCharacter = bs::GameObjectHandle<Character>;
 
@@ -126,6 +129,14 @@ namespace REGoth
     HWaynet waynet() const
     {
       return mWaynet;
+    }
+
+    /**
+     * @return  Handle to the GameClock of the world.
+     */
+    HGameClock gameclock() const
+    {
+      return mGameClock;
     }
 
     /**
@@ -280,6 +291,11 @@ namespace REGoth
      * Access to the Waynet of this world.
      */
     HWaynet mWaynet;
+
+    /**
+     * Access to the GameClock of this World.
+     */
+    HGameClock mGameClock;
 
     /**
      * Script-VM with GOTHIC.DAT loaded.

--- a/src/scripting/daedalus/DaedalusVMForGameWorld.cpp
+++ b/src/scripting/daedalus/DaedalusVMForGameWorld.cpp
@@ -5,6 +5,7 @@
 #include <components/Character.hpp>
 #include <components/GameWorld.hpp>
 #include <components/VisualCharacter.hpp>
+#include <components/GameClock.hpp>
 
 namespace REGoth
 {
@@ -141,6 +142,9 @@ namespace REGoth
       registerExternal("CREATEINVITEM", (externalCallback)&This::external_NPC_CreateInventoryItem);
       registerExternal("MDL_SETVISUAL", (externalCallback)&This::external_MDL_SetVisual);
       registerExternal("MDL_SETVISUALBODY", (externalCallback)&This::external_MDL_SetVisualBody);
+      registerExternal("WLD_GETDAY", (externalCallback)&This::external_WLD_GetDay);
+      registerExternal("WLD_ISTIME", (externalCallback)&This::external_WLD_IsTime);
+      registerExternal("WLD_SETTIME", (externalCallback)&This::external_WLD_SetTime);
     }
 
     void DaedalusVMForGameWorld::external_Print()
@@ -187,6 +191,33 @@ namespace REGoth
       SymbolIndex instance = popIntValue();
 
       mWorld->insertCharacter(mScriptSymbols.getSymbolName(instance), waypoint);
+    }
+
+    void DaedalusVMForGameWorld::external_WLD_GetDay()
+    {
+      bs::INT32 day = mWorld->gameclock()->getDay();
+
+      mStack.pushInt(day);
+    }
+
+    void DaedalusVMForGameWorld::external_WLD_IsTime()
+    {
+      bs::INT32 min2  = popIntValue();
+      bs::INT32 hour2 = popIntValue();
+      bs::INT32 min1  = popIntValue();
+      bs::INT32 hour1 = popIntValue();
+
+      bool test = mWorld->gameclock()->isTime(hour1, min1, hour2, min2);
+
+      mStack.pushInt(test ? 1 : 0);
+    }
+
+    void DaedalusVMForGameWorld::external_WLD_SetTime()
+    {
+      bs::INT32 min  = popIntValue();
+      bs::INT32 hour = popIntValue();
+
+      mWorld->gameclock()->setTime(hour, min);
     }
 
     void DaedalusVMForGameWorld::external_NPC_IsPlayer()

--- a/src/scripting/daedalus/DaedalusVMForGameWorld.hpp
+++ b/src/scripting/daedalus/DaedalusVMForGameWorld.hpp
@@ -70,6 +70,9 @@ namespace REGoth
       void external_ConcatStrings();
       void external_WLD_InsertItem();
       void external_WLD_InsertNpc();
+      void external_WLD_GetDay();
+      void external_WLD_IsTime();
+      void external_WLD_SetTime();
       void external_NPC_IsPlayer();
       void external_NPC_SetTalentSkill();
       void external_NPC_EquipItem();


### PR DESCRIPTION
Implements the GameClock component.
Not currently integrated to the world at all ;D.
It also keeps track of the elapsed real-time seconds for fun. Maybe this is useful somehow or can be used to display playtime somewhere.

The functionality is derived from the three Wld_* externals that do something with the time/clock.
If there are more features needed, let me know.