### PR TITLE
Fix typo in RTTI declaration

### DIFF
--- a/src/RTTI/RTTIUtil.hpp
+++ b/src/RTTI/RTTIUtil.hpp
@@ -37,11 +37,11 @@
  * note that there is not semicolon after the makro!
  * Futhermore, the makro invocation needs to be in `public`-land of the component.
  */
-#define REGOTH_DECLARE_RTTI(classname)      \
-  friend class bs::SceneObject;             \
-  friend class RTTI_##classname;            \
-  static bs::RTTITypeBase* getRTTIStatic(); \
-  bs::RTTITypeBase* getRTTI() const override;
+#define REGOTH_DECLARE_RTTI(classname)                           \
+  friend class bs::SceneObject;                                  \
+  friend class RTTI_##classname;                                 \
+  static bs::RTTITypeBase* getRTTIStatic();                      \
+  decltype(classname::getRTTIStatic()) getRTTI() const override; 
 
 /**
  * For use in the actual components source. Defines the functions for accessing

--- a/src/components/VisualInteractiveObject.hpp
+++ b/src/components/VisualInteractiveObject.hpp
@@ -22,7 +22,7 @@ namespace REGoth
     bs::Vector<bs::String> listPossibleDefaultAnimations() const override;
 
   public:
-    REGOTH_DECLARE_RTTI(Character);
+    REGOTH_DECLARE_RTTI(VisualInteractiveObject);
 
   protected:
     VisualInteractiveObject() = default; // For RTTI


### PR DESCRIPTION
Just fixing a small typo in the RTTI declaration of `VisualInteractiveObject` I discovered when toying around with the RTTI macros. Funny enough, it worked before.