### PR TITLE
Vob Collision

### DIFF
--- a/src/components/GameWorld.cpp
+++ b/src/components/GameWorld.cpp
@@ -46,7 +46,12 @@ namespace REGoth
     if (!mZenFile.empty())
     {
       // Import the ZEN and add all scene objects as children to this SO.
-      Internals::constructFromZEN(SO(), mZenFile);
+      bs::HSceneObject so = Internals::constructFromZEN(SO(), mZenFile);
+
+      if (!so)
+      {
+        REGOTH_THROW(InvalidParametersException, "Failed to import ZEN-file: " + mZenFile);
+      }
 
       findWaynet();
     }


### PR DESCRIPTION
This PR adds collision meshes to Objects which have the "Collide with Stuff"-flag set in the ZEN-file (`cdDyn`).

Might want to move this to a different place later, so we can dynamically instantiate objects with collision more easily, so this is kept rather simple.