### PR TITLE
Update BsZenLib (Import Textures as sRGB)

### DIFF
--- a/src/REGothEngine.cpp
+++ b/src/REGothEngine.cpp
@@ -154,8 +154,8 @@ void REGothEngine::setupMainCamera()
   rs->enableTonemapping              = false;
   rs->enableAutoExposure             = false;
   rs->enableSkybox                   = false;
-  rs->exposureScale                  = 1.0f;
-  rs->gamma                          = 1.5f;
+  rs->exposureScale                  = 0.f;
+  rs->gamma                          = 2.f;
   rs->cullDistance                   = 100.0f;
 
   sceneCamera->setRenderSettings(rs);


### PR DESCRIPTION
Fixes Textures not being imported as sRGB. 

Before:
![image](https://user-images.githubusercontent.com/11406580/58584377-7304bf00-8256-11e9-8d84-6d90e847a174.png)

After:
![image](https://user-images.githubusercontent.com/11406580/58584357-67b19380-8256-11e9-8d17-5265ac3aada0.png)
