### PR TITLE
Sky color

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,10 @@ add_library(REGothEngine
   components/EventQueue.cpp
   components/CharacterEventQueue.hpp
   components/CharacterEventQueue.cpp
+  components/Sky.hpp
+  components/Sky.cpp
+  sky/SkyColoring.hpp
+  sky/SkyColoring.cpp
   AI/EventMessage.hpp
   AI/EventMessage.cpp
   AI/ScriptState.hpp

--- a/src/RTTI/RTTI_Sky.hpp
+++ b/src/RTTI/RTTI_Sky.hpp
@@ -1,0 +1,20 @@
+#include "RTTIUtil.hpp"
+#include <components/Sky.hpp>
+
+namespace REGoth
+{
+  class RTTI_Sky
+      : public bs::RTTIType<Sky, bs::Component, RTTI_Sky>
+  {
+    BS_BEGIN_RTTI_MEMBERS
+    BS_RTTI_MEMBER_REFL(mGameWorld, 0)
+    BS_END_RTTI_MEMBERS
+
+  public:
+    RTTI_Sky()
+    {
+    }
+
+    REGOTH_IMPLEMENT_RTTI_CLASS_FOR_COMPONENT(Sky)
+  };
+}  // namespace REGoth

--- a/src/RTTI/RTTI_TypeIDs.hpp
+++ b/src/RTTI/RTTI_TypeIDs.hpp
@@ -62,5 +62,6 @@ namespace REGoth
     TID_REGOTH_ScriptState                  = 600054,
     TID_REGOTH_RoutineTask                  = 600055,
     TID_REGOTH_Freepoint                    = 600056,
+    TID_REGOTH_Sky                          = 600057,
   };
 }  // namespace REGoth

--- a/src/components/GameClock.cpp
+++ b/src/components/GameClock.cpp
@@ -1,24 +1,27 @@
 #include "GameClock.hpp"
+#include <Math/BsMath.h>
 #include <RTTI/RTTI_GameClock.hpp>
 #include <Scene/BsSceneObject.h>
-#include <Math/BsMath.h>
 
 namespace REGoth
 {
   constexpr float SECONDS_IN_A_MINUTE = 60;
   constexpr float SECONDS_IN_AN_HOUR  = 60 * SECONDS_IN_A_MINUTE;
   constexpr float SECONDS_IN_A_DAY    = 24 * SECONDS_IN_AN_HOUR;
-  constexpr float CLOCK_SPEED_FACTOR  = SECONDS_IN_A_DAY/6000; // see https://forum.worldofplayers.de/forum/threads/396326-Tipp-Tageweise-springen-%28auch-zur%C3%BCck%29?p=6231841&viewfull=1#post6231841
+  // see
+  // https://forum.worldofplayers.de/forum/threads/396326?p=6231841&viewfull=1#post6231841
+  constexpr float CLOCK_SPEED_FACTOR = SECONDS_IN_A_DAY / 6000;
 
   GameClock::GameClock(const bs::HSceneObject& parent)
-    : bs::Component(parent)
-  { }
+      : bs::Component(parent)
+  {
+  }
 
   void GameClock::fixedUpdate()
   {
     float delta = bs::gTime().getFixedFrameDelta();
 
-    mElapsedSeconds       += delta;
+    mElapsedSeconds += delta;
     mElapsedIngameSeconds += delta * CLOCK_SPEED_FACTOR;
   }
 
@@ -29,47 +32,59 @@ namespace REGoth
 
   bs::INT32 GameClock::getHour() const
   {
-    float elapsedSecondsOfDay = mElapsedIngameSeconds - (getDay() * SECONDS_IN_A_DAY);
-    
-    return bs::Math::floorToPosInt(elapsedSecondsOfDay / SECONDS_IN_AN_HOUR);
+    return bs::Math::floorToPosInt(getDaySeconds() / SECONDS_IN_AN_HOUR);
   }
 
   bs::INT32 GameClock::getMinute() const
   {
-    float elapsedSecondsOfHour = mElapsedIngameSeconds - (getDay() * SECONDS_IN_A_DAY) - (getHour() * SECONDS_IN_AN_HOUR);
+    float elapsedSecondsOfHour = getDaySeconds() - (getHour() * SECONDS_IN_AN_HOUR);
 
     return bs::Math::floorToPosInt(elapsedSecondsOfHour / SECONDS_IN_A_MINUTE);
+  }
+
+  float GameClock::getDayRatio() const
+  {
+    return getDaySeconds() / SECONDS_IN_A_DAY;
+  }
+
+  float GameClock::getDaySeconds() const
+  {
+    return mElapsedIngameSeconds - (getDay() * SECONDS_IN_A_DAY);
   }
 
   bool GameClock::isTime(bs::INT32 hour1, bs::INT32 min1, bs::INT32 hour2, bs::INT32 min2) const
   {
     // TODO: Do we need to handle negative input parameters smaller than -24?
     hour1 = (hour1 + 24) % 24;
-    min1  = (min1  + 60) % 60;
+    min1  = (min1 + 60) % 60;
     hour2 = (hour2 + 24) % 24;
-    min2  = (min2  + 60) % 60;
+    min2  = (min2 + 60) % 60;
 
-    float currentTimeOfDayInSeconds = mElapsedIngameSeconds - (getDay() * SECONDS_IN_A_DAY);
-    float firstTimeOfDayInSeconds   = (hour1*SECONDS_IN_AN_HOUR + min1*SECONDS_IN_A_MINUTE);
-    float secondTimeOfDayInSeconds  = (hour2*SECONDS_IN_AN_HOUR + min2*SECONDS_IN_A_MINUTE);
+    float currentTimeOfDayInSeconds = getDaySeconds();
+    float firstTimeOfDayInSeconds   = (hour1 * SECONDS_IN_AN_HOUR + min1 * SECONDS_IN_A_MINUTE);
+    float secondTimeOfDayInSeconds  = (hour2 * SECONDS_IN_AN_HOUR + min2 * SECONDS_IN_A_MINUTE);
 
     if (firstTimeOfDayInSeconds != secondTimeOfDayInSeconds)
     {
-      secondTimeOfDayInSeconds -= 60.0; // Gothic subtracts one minute from the second time here to counter issues happening with overlapping times for Daily Routines. - markusobi
+      // Gothic subtracts one minute from the second time here to counter issues happening
+      // with overlapping times for Daily Routines. - markusobi
+      secondTimeOfDayInSeconds -= 60.0;
     }
 
     bool retval;
-    if ( hour1 == hour2 && min1 == min2)
+    if (hour1 == hour2 && min1 == min2)
     {
       retval = false;
     }
     else if (firstTimeOfDayInSeconds > secondTimeOfDayInSeconds)
     {
-      retval = (currentTimeOfDayInSeconds >= firstTimeOfDayInSeconds) || (currentTimeOfDayInSeconds <= secondTimeOfDayInSeconds);
+      retval = (currentTimeOfDayInSeconds >= firstTimeOfDayInSeconds) ||
+               (currentTimeOfDayInSeconds <= secondTimeOfDayInSeconds);
     }
     else /* firstTimeOfDayInSeconds < secondTimeOfDayInSeconds */
     {
-      retval = (currentTimeOfDayInSeconds >= firstTimeOfDayInSeconds) && (currentTimeOfDayInSeconds <= secondTimeOfDayInSeconds);
+      retval = (currentTimeOfDayInSeconds >= firstTimeOfDayInSeconds) &&
+               (currentTimeOfDayInSeconds <= secondTimeOfDayInSeconds);
     }
 
     return retval;
@@ -77,18 +92,20 @@ namespace REGoth
 
   void GameClock::setTime(bs::INT32 hour, bs::INT32 min)
   {
-    // TODO: Negative input parameters are supported for hour, but what about negative values that result in negative remaining hours?
+    // TODO: Negative input parameters are supported for hour, but what about negative values that
+    // result in negative remaining hours?
     //       Do we need to handle negative Minutes at all?
-    bs::INT32 daysToAdvance    = hour / 24;
-    bs::INT32 day = getDay()+daysToAdvance;
-    hour = hour % 24;
-    min  = min % 60;
+    bs::INT32 daysToAdvance = hour / 24;
+    bs::INT32 day           = getDay() + daysToAdvance;
+    hour                    = hour % 24;
+    min                     = min % 60;
 
     setTime((bs::UINT32)day, (bs::UINT8)hour, (bs::UINT8)min);
 
-    // TODO: According to https://forum.worldofplayers.de/forum/threads/396326-Tipp-Tageweise-springen-%28auch-zur%C3%BCck%29?p=6231841&viewfull=1#post6231841
-    //       if this shall be the Wld_setTime external, it also needs to implement these three functions here
-    //       RoutineManager.SetDailyRoutinePos(RoutinesOnly)
+    // TODO: According to
+    //       https://forum.worldofplayers.de/forum/threads/396326?p=6231841&viewfull=1#post6231841
+    //       if this shall be the Wld_setTime external, it also needs to implement these three
+    //       functions here RoutineManager.SetDailyRoutinePos(RoutinesOnly)
     //       Game.SetObjectRoutineTimeChange(GameHour, GameMinute, Hour, Minute)
     //       SpawnManager.SpawnImmediately(ResetSpawnTime)
   }
@@ -96,14 +113,15 @@ namespace REGoth
   void GameClock::setDay(bs::UINT32 day)
   {
     bs::UINT8 hour = (bs::UINT8)getHour();
-    bs::UINT8 min = (bs::UINT8)getMinute();
+    bs::UINT8 min  = (bs::UINT8)getMinute();
 
     setTime(day, hour, min);
   }
 
   void GameClock::setTime(bs::UINT32 day, bs::UINT8 hour, bs::UINT8 min)
   {
-    mElapsedIngameSeconds = day*SECONDS_IN_A_DAY + hour*SECONDS_IN_AN_HOUR + min*SECONDS_IN_A_MINUTE;
+    mElapsedIngameSeconds =
+        day * SECONDS_IN_A_DAY + hour * SECONDS_IN_AN_HOUR + min * SECONDS_IN_A_MINUTE;
   }
 
   REGOTH_DEFINE_RTTI(GameClock)

--- a/src/components/GameClock.hpp
+++ b/src/components/GameClock.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include <BsPrerequisites.h>
+#include <RTTI/RTTIUtil.hpp>
 #include <Scene/BsComponent.h>
 #include <Utility/BsTime.h>
-#include <RTTI/RTTIUtil.hpp>
 
 namespace REGoth
 {
@@ -37,7 +37,22 @@ namespace REGoth
     bs::INT32 getMinute() const;
 
     /**
-     * @return  Whether the current ingame time of day (hh::mm) is between the two given times of day.
+     * @return Ratio of how far the current day has progressed.
+     *         If the clock says 0:00, this will return 0.0f.
+     *         IF the clock says 23:59, a value close to 1.0f will be returned.
+     */
+    float getDayRatio() const;
+
+    /**
+     * @return Number of seconds elapsed in the current day counted in ingame-time.
+     *         This resets to 0 when a new day starts.
+     *         The maximum value this will return is 60 * 60 * 24.
+     */
+    float getDaySeconds() const;
+
+    /**
+     * @return  Whether the current ingame time of day (hh::mm) is between the two given times of
+     * day.
      *
      * @note    The first time of day can be after the second time of day.
      *
@@ -51,10 +66,10 @@ namespace REGoth
      *              Minute of the second time of day (\p hour2 : \p min2 ) to check against.
      */
     bool isTime(bs::INT32 hour1, bs::INT32 min1, bs::INT32 hour2, bs::INT32 min2) const;
-    
+
     /**
      * Sets the ingame clock (hh:mm) to the given time in hour and minute.
-     * 
+     *
      * @note   Values for \p hour can be over 23 to advance days too.
      *         Calling setTime(24+15, 0) sets the clock to 15:00 and advances one day.
      *
@@ -74,14 +89,10 @@ namespace REGoth
 
     void setTime(bs::UINT32 day, bs::UINT8 hour, bs::UINT8 min);
 
-  /************************************************************************/
-  /* RTTI                                                                 */
-  /************************************************************************/
   public:
     REGOTH_DECLARE_RTTI(GameClock)
 
-  // protected:
-  public:  // FIXME: Should be protected, it is only used by RTTI but friend doesn't seem to work?!
+  protected:
     GameClock() = default;  // Serialization only
   };
 

--- a/src/components/GameWorld.cpp
+++ b/src/components/GameWorld.cpp
@@ -1,4 +1,5 @@
 #include "GameWorld.hpp"
+#include <components/Sky.hpp>
 #include <BsZenLib/ImportPath.hpp>
 #include <RTTI/RTTI_GameWorld.hpp>
 #include <Resources/BsResources.h>
@@ -36,6 +37,8 @@ namespace REGoth
 
   void GameWorld::onInitialized()
   {
+    HGameWorld thisWorld = bs::static_object_cast<GameWorld>(getHandle());
+
     // Always do this after importing or deserializing
     fillFindByNameCache();
 
@@ -46,8 +49,6 @@ namespace REGoth
 
     if (!mZenFile.empty())
     {
-      HGameWorld thisWorld = bs::static_object_cast<GameWorld>(getHandle());
-
       // Import the ZEN and add all scene objects as children to this SO.
       bs::HSceneObject so = Internals::constructFromZEN(thisWorld, mZenFile);
 
@@ -68,6 +69,8 @@ namespace REGoth
 
     mGameClock = SO()->addComponent<GameClock>();
     mGameClock->setTime(8, 0);
+
+    SO()->addComponent<Sky>(thisWorld);
 
     mIsInitialized = true;
   }

--- a/src/components/Sky.cpp
+++ b/src/components/Sky.cpp
@@ -1,0 +1,58 @@
+#include "Sky.hpp"
+#include <RenderAPI/BsViewport.h>
+#include <Renderer/BsCamera.h>
+#include <RTTI/RTTI_Sky.hpp>
+#include <Scene/BsSceneManager.h>
+#include <components/GameClock.hpp>
+#include <components/GameWorld.hpp>
+#include <sky/SkyColoring.hpp>
+
+namespace REGoth
+{
+  Sky::Sky(const bs::HSceneObject& parent, HGameWorld gameWorld)
+      : bs::Component(parent)
+      , mGameWorld(gameWorld)
+  {
+    setName("Sky");
+  }
+
+  Sky::~Sky()
+  {
+  }
+
+  void Sky::onInitialized()
+  {
+    if (!mSkyColoring)
+    {
+      mSkyColoring = bs::bs_shared_ptr_new<SkyColoring>();
+      mSkyColoring->fillSkyStates();
+    }
+  }
+
+  void Sky::update()
+  {
+    mSkyColoring->interpolate(mGameWorld->gameclock()->getDayRatio());
+
+    applySkySettingsToCamera();
+  }
+
+  void Sky::applySkySettingsToCamera() const
+  {
+    const auto& camera = bs::gSceneManager().getMainCamera();
+    float near;
+    float far;
+    bs::Color fogColor;
+
+    mSkyColoring->calculateFogDistanceAndColor(near, far, fogColor);
+
+    // TODO: Use fog near and far
+    (void)near;
+    (void)far;
+
+    // FIXME: Fog color can actually be a little bit different. Get the correct color from master state.
+    camera->getViewport()->setClearColorValue(fogColor);
+  }
+
+  REGOTH_DEFINE_RTTI(Sky)
+
+}  // namespace REGoth

--- a/src/components/Sky.hpp
+++ b/src/components/Sky.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include <RTTI/RTTIUtil.hpp>
+#include <Scene/BsComponent.h>
+
+namespace REGoth
+{
+  class SkyColoring;
+
+  class GameWorld;
+  using HGameWorld = bs::GameObjectHandle<GameWorld>;
+
+  /**
+   * TODO: Documentation of Sky
+   */
+  class Sky : public bs::Component
+  {
+  public:
+    Sky(const bs::HSceneObject& parent, HGameWorld gameWorld);
+    virtual ~Sky();
+
+    void onInitialized() override;
+
+    void update() override;
+
+  private:
+
+    void applySkySettingsToCamera() const;
+
+    bs::SPtr<SkyColoring> mSkyColoring;
+    HGameWorld mGameWorld;
+
+  public:
+    REGOTH_DECLARE_RTTI(Sky)
+
+  protected:
+    Sky() = default;  // For RTTI
+  };
+}  // namespace REGoth

--- a/src/sky/SkyColoring.cpp
+++ b/src/sky/SkyColoring.cpp
@@ -1,0 +1,391 @@
+#include "SkyColoring.hpp"
+#include <Image/BsColor.h>
+#include <Math/BsMath.h>
+#include <Renderer/BsCamera.h>
+#include <Scene/BsSceneManager.h>
+
+namespace REGoth
+{
+  // These must be ordered, starting at 0.00f
+  constexpr float TIME_KEY_0 = 0.00f;
+  constexpr float TIME_KEY_1 = 0.25f;
+  constexpr float TIME_KEY_2 = 0.30f;
+  constexpr float TIME_KEY_3 = 0.35f;
+  constexpr float TIME_KEY_4 = 0.50f;
+  constexpr float TIME_KEY_5 = 0.65f;
+  constexpr float TIME_KEY_6 = 0.70f;
+  constexpr float TIME_KEY_7 = 0.75f;
+
+  static_assert(TIME_KEY_0 == 0.00f, "TIME_KEY_0 must be 0.0f!");
+
+  SkyColoring::SkyColoring()
+  {
+  }
+
+  SkyColoring::~SkyColoring()
+  {
+  }
+
+  void SkyColoring::getSkyColors(bs::Color& color0, bs::Color& color1)
+  {
+    color0 = bs::Color(0.0f, 0.0f, 0.0f, 0.0f);
+    color1 = mMasterState.baseColor;
+  }
+
+  void SkyColoring::interpolate(float dayRatio)
+  {
+    mMasterState.time = std::fmod(dayRatio + 0.5, 1.0);
+
+    bs::UINT32 si0;
+    bs::UINT32 si1;
+
+    findTwoSkyStatesToInterpolateBetween(si0, si1);
+
+    SkyState& s0 = mSkyStates[si0];
+    SkyState& s1 = mSkyStates[si1];
+
+    interpolateAndStoreIntoMasterState(s0, s1);
+
+    // FIXME: There is some stuff about levelchanges here. Like, "turn off rain when on dragonisland"
+
+    // FIXME: Multiply fogColor with 0.8 when using dome!
+  }
+
+  void SkyColoring::findTwoSkyStatesToInterpolateBetween(bs::UINT32& s0, bs::UINT32& s1) const
+  {
+    // init with values for case: time >= TIME_KEY_7 (= 0.75f)
+    s0 = (bs::INT32)mSkyStates.size() - 1;
+    s1 = 0;
+
+    for (bs::UINT32 i = 0; i < (bs::UINT32)mSkyStates.size(); i++)
+    {
+      // Since the sky states are ordered, our start state is the first one which is supposed
+      // to start *before* the current time. The target state is then the one right after.
+      // Since it's easier to search for the target state, which is the first state which has a
+      // time larger than the current time, we search for that. The start state is the one
+      // right before it.
+      if (mMasterState.time < mSkyStates[i].time)
+      {
+        // Subtracting 1 will not cause a negative numbers here since the first state has a
+        // time of 0.0, so the check should never pass for it. If everything is set up correctly
+        // that is.
+        s0 = (i - 1) % mSkyStates.size();
+        s1 = i % mSkyStates.size();
+        break;
+      }
+    }
+  }
+
+  void SkyColoring::interpolateAndStoreIntoMasterState(const SkyState& s0, const SkyState& s1)
+  {
+    // Handle case time >= TIME_KEY_7 (= 0.75f)
+    float timeS1 = s1.time < s0.time ? s1.time + 1.0f : s1.time;
+
+    // Scale up time difference to [0,1]
+    float t = (mMasterState.time - s0.time) / (timeS1 - s0.time);
+
+    // Interpolate values
+    mMasterState.baseColor      = s0.baseColor + t * (s1.baseColor - s0.baseColor);
+    mMasterState.fogColor       = s0.fogColor + t * (s1.fogColor - s0.fogColor);
+    mMasterState.fogDistance    = s0.fogDistance + t * (s1.fogDistance - s0.fogDistance);
+    mMasterState.domeColorUpper = s0.domeColorUpper + t * (s1.domeColorUpper - s0.domeColorUpper);
+
+    mMasterState.cloudsLayer = s0.cloudsLayer;
+    mMasterState.cloudsLayer.textureAlpha =
+        bs::Math::lerp(t, s0.cloudsLayer.textureAlpha, s1.cloudsLayer.textureAlpha);
+    mMasterState.cloudsLayer.textureScale =
+        bs::Math::lerp(t, s0.cloudsLayer.textureScale, s1.cloudsLayer.textureScale);
+
+    mMasterState.skyLayer = s0.skyLayer;
+    mMasterState.skyLayer.textureAlpha =
+        bs::Math::lerp(t, s0.skyLayer.textureAlpha, s1.skyLayer.textureAlpha);
+    mMasterState.skyLayer.textureScale =
+        bs::Math::lerp(t, s0.skyLayer.textureScale, s1.skyLayer.textureScale);
+  }
+
+  void SkyColoring::initSkyState(SkyPresetType type, SkyColoring::SkyState& s)
+  {
+    bs::Color skyColor_g1 = bs::Color(114, 93, 82) / 255.0f;    // G1
+    bs::Color skyColor_g2 = bs::Color(120, 140, 180) / 255.0f;  // G2
+
+    // TODO: Figure out game type and chose sky color accordingly
+    bs::Color skyColor = skyColor_g2;
+
+    switch (type)
+    {
+      case SkyPresetType::Day0:
+        s.time = TIME_KEY_7;
+
+        s.baseColor      = bs::Color(255, 250, 235) / 255.0f;
+        s.fogColor       = skyColor;
+        s.domeColorUpper = bs::Color(255, 255, 255) / 255.0f;
+
+        s.fogDistance = 0.2f;
+        s.isSunActive = true;
+
+        s.cloudsLayer.textureNameBase = "SKYDAY_LAYER1_A0.TGA";
+        s.cloudsLayer.textureAlpha    = 0.0f;
+        s.cloudsLayer.textureSpeed    = bs::Vector2(1.1f, 0);
+        s.cloudsLayer.textureScale    = 1.0f;
+
+        s.skyLayer.textureNameBase = "SKYDAY_LAYER0_A0.TGA";
+        s.skyLayer.textureAlpha    = 1.0f;
+        s.skyLayer.textureSpeed    = bs::Vector2(0.3f, 0);
+        s.skyLayer.textureScale    = 1.0f;
+        break;
+
+      case SkyPresetType::Day1:
+        s.time = TIME_KEY_0;
+
+        s.baseColor      = bs::Color(255, 250, 235) / 255.0f;
+        s.fogColor       = skyColor;
+        s.domeColorUpper = bs::Color(255, 255, 255) / 255.0f;
+
+        s.fogDistance = 0.05f;
+        s.isSunActive = true;
+
+        s.cloudsLayer.textureNameBase = "SKYDAY_LAYER1_A0.TGA";
+        s.cloudsLayer.textureAlpha    = 215.0f / 255.0f;
+        s.cloudsLayer.textureSpeed    = bs::Vector2(1.1f, 0);
+        s.cloudsLayer.textureScale    = 1.0f;
+
+        s.skyLayer.textureNameBase = "SKYDAY_LAYER0_A0.TGA";
+        s.skyLayer.textureAlpha    = 1.0f;
+        s.skyLayer.textureSpeed    = bs::Vector2(0.3f, 0);
+        s.skyLayer.textureScale    = 1.0f;
+        break;
+
+      case SkyPresetType::Day2:
+        s.time = TIME_KEY_1;
+
+        s.baseColor      = bs::Color(255, 250, 235) / 255.0f;
+        s.fogColor       = skyColor;
+        s.domeColorUpper = bs::Color(255, 255, 255) / 255.0f;
+
+        s.fogDistance = 0.05f;
+        s.isSunActive = true;
+
+        s.cloudsLayer.textureNameBase = "SKYDAY_LAYER1_A0.TGA";
+        s.cloudsLayer.textureAlpha    = 0.0f;
+        s.cloudsLayer.textureSpeed    = bs::Vector2(1.1f, 0);
+        s.cloudsLayer.textureScale    = 1.0f;
+
+        s.skyLayer.textureNameBase = "SKYDAY_LAYER0_A0.TGA";
+        s.skyLayer.textureAlpha    = 1.0f;
+        s.skyLayer.textureSpeed    = bs::Vector2(0.3f, 0);
+        s.skyLayer.textureScale    = 1.0f;
+        break;
+
+      case SkyPresetType::Evening:
+        s.time = TIME_KEY_2;
+
+        s.baseColor      = bs::Color(255, 185, 170) / 255.0f;
+        s.fogColor       = bs::Color(170, 70, 50) / 255.0f;
+        s.domeColorUpper = bs::Color(255, 255, 255) / 255.0f;
+
+        s.fogDistance = 0.2f;
+        s.isSunActive = true;
+
+        s.cloudsLayer.textureNameBase = "SKYDAY_LAYER1_A0.TGA";
+        s.cloudsLayer.textureAlpha    = 0.5f;
+        s.cloudsLayer.textureSpeed    = bs::Vector2(1.1f, 0);
+        s.cloudsLayer.textureScale    = 1.0f;
+
+        s.skyLayer.textureNameBase = "SKYDAY_LAYER0_A0.TGA";
+        s.skyLayer.textureAlpha    = 0.5f;
+        s.skyLayer.textureSpeed    = bs::Vector2(0.3f, 0);
+        s.skyLayer.textureScale    = 1.0f;
+        break;
+
+      case SkyPresetType::Night0:
+        s.time = TIME_KEY_3;
+
+        s.baseColor      = bs::Color(105, 105, 195) / 255.0f;
+        s.fogColor       = bs::Color(20, 20, 60) / 255.0f;
+        s.domeColorUpper = bs::Color(55, 55, 155) / 255.0f;
+
+        s.fogDistance = 0.1f;
+        s.isSunActive = false;
+
+        s.cloudsLayer.textureNameBase = "SKYNIGHT_LAYER0_A0.TGA";
+        s.cloudsLayer.textureAlpha    = 1.0f;
+        s.cloudsLayer.textureSpeed    = bs::Vector2(0.0f, 0);
+        s.cloudsLayer.textureScale    = 4.0f;
+
+        s.skyLayer.textureNameBase = "SKYNIGHT_LAYER1_A0.TGA";
+        s.skyLayer.textureAlpha    = 0.0f;
+        s.skyLayer.textureSpeed    = bs::Vector2(0.0f, 0);
+        s.skyLayer.textureScale    = 1.0f;
+        break;
+
+      case SkyPresetType::Night1:
+        s.time = TIME_KEY_4;
+
+        s.baseColor      = bs::Color(40, 60, 210) / 255.0f;
+        s.fogColor       = bs::Color(5, 5, 20) / 255.0f;
+        s.domeColorUpper = bs::Color(55, 55, 155) / 255.0f;
+
+        s.fogDistance = 0.1f;
+        s.isSunActive = false;
+
+        s.cloudsLayer.textureNameBase = "SKYNIGHT_LAYER0_A0.TGA";
+        s.cloudsLayer.textureAlpha    = 1.0f;
+        s.cloudsLayer.textureSpeed    = bs::Vector2(0.0f, 0);
+        s.cloudsLayer.textureScale    = 4.0f;
+
+        s.skyLayer.textureNameBase = "SKYNIGHT_LAYER1_A0.TGA";
+        s.skyLayer.textureAlpha    = 215.0f / 255.0f;
+        s.skyLayer.textureSpeed    = bs::Vector2(0.0f, 0);
+        s.skyLayer.textureScale    = 1.0f;
+        break;
+
+      case SkyPresetType::Night2:
+        s.time = TIME_KEY_5;
+
+        s.baseColor      = bs::Color(40, 60, 210) / 255.0f;
+        s.fogColor       = bs::Color(5, 5, 20) / 255.0f;
+        s.domeColorUpper = bs::Color(55, 55, 155) / 255.0f;
+
+        s.fogDistance = 0.1f;
+        s.isSunActive = false;
+
+        s.cloudsLayer.textureNameBase = "SKYNIGHT_LAYER0_A0.TGA";
+        s.cloudsLayer.textureAlpha    = 1.0f;
+        s.cloudsLayer.textureSpeed    = bs::Vector2(0.0f, 0);
+        s.cloudsLayer.textureScale    = 4.0f;
+
+        s.skyLayer.textureNameBase = "SKYNIGHT_LAYER1_A0.TGA";
+        s.skyLayer.textureAlpha    = 0.0f;
+        s.skyLayer.textureSpeed    = bs::Vector2(0.0f, 0);
+        s.skyLayer.textureScale    = 1.0f;
+        break;
+
+      case SkyPresetType::Dawn:
+        s.time = TIME_KEY_6;
+
+        s.baseColor      = bs::Color(190, 160, 255) / 255.0f;
+        s.fogColor       = bs::Color(80, 60, 105) / 255.0f;
+        s.domeColorUpper = bs::Color(255, 255, 255) / 255.0f;
+
+        s.fogDistance = 0.5f;
+        s.isSunActive = true;
+
+        s.cloudsLayer.textureNameBase = "SKYNIGHT_LAYER0_A0.TGA";
+        s.cloudsLayer.textureAlpha    = 0.5f;
+        s.cloudsLayer.textureSpeed    = bs::Vector2(1.1f, 0);
+        s.cloudsLayer.textureScale    = 1.0f;
+
+        s.skyLayer.textureNameBase = "SKYNIGHT_LAYER1_A0.TGA";
+        s.skyLayer.textureAlpha    = 0.5f;
+        s.skyLayer.textureSpeed    = bs::Vector2(0.3f, 0);
+        s.skyLayer.textureScale    = 1.0f;
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  void SkyColoring::fillSkyStates()
+  {
+    // Fill all sky-states, in order
+    for (int i = 0; i < mSkyStates.size(); i++)
+    {
+      initSkyState(static_cast<SkyPresetType>(i), mSkyStates[i]);
+    }
+  }
+
+  void SkyColoring::calculateFogDistanceAndColor(float& nearFog, float& farFog,
+                                                 bs::Color& finalFogColor) const
+  {
+    float farPlane             = bs::gSceneManager().getMainCamera()->getFarClipDistance();
+    bs::Vector3 cameraPosition = bs::gSceneManager().getMainCamera()->getTransform().pos();
+
+    // FIXME: Find proper bounds. Using the world mesh would be okay here.
+    bs::AABox worldBBox = bs::AABox(bs::Vector3(0, 0, 0), bs::Vector3(100, 100, 100));
+
+    // Note: These are some magic values to match what gothic does
+    float fogMidrange = farPlane * 0.4f;
+    float fogMidDelta = farPlane - fogMidrange;
+
+    // Do heightfog-approximation
+    float ytotal  = worldBBox.getMax().y - worldBBox.getMin().y;
+    float fogMinY = worldBBox.getMin().y + 0.5f * ytotal;
+    float fogMaxY = worldBBox.getMin().y + 0.7f * ytotal;
+
+    // Scale fog back depending on how high the camera is
+    float fogScale = fogMaxY - fogMinY != 0 ? (cameraPosition.y - fogMinY) / (fogMaxY - fogMinY) : 0;
+
+    fogScale = bs::Math::clamp(fogScale, 0.0f, 1.0f);
+
+    // Fog should be at least our set distance
+    fogScale = bs::Math::max(mMasterState.fogDistance, fogScale);
+
+    farFog = fogMidrange + (1.0f - fogScale) * fogMidDelta;
+
+    // Apply some user value // FIXME: This should have a getter/setter and all that stuff
+    const float userFogScale = 1.0f;
+    farFog *= userFogScale;
+    nearFog = farFog * 0.3f;
+
+    // REGoth - specific: Let the fog be a little closer because of the long view-distances
+    nearFog *= 0.5f;
+
+    farFog *= 0.4f;
+    nearFog *= 0.4f;
+
+    // Fix up the fog color. The fog should get less intense with decrasing fogFar
+
+    // Compute intensity based on the ZenGins color-base
+    bs::Color base = bs::Color(0.299f, 0.587f, 0.114f);
+
+    // Original engine uses only the red component here as well. Who knows why.
+    bs::Color baseColor =
+        bs::Color(mMasterState.fogColor.r, mMasterState.fogColor.r, mMasterState.fogColor.r);
+
+    // Calculate intensity
+    float intensityValue = std::min(
+        baseColor.r * base.r + baseColor.g * base.g + baseColor.b * base.b, 120.0f / 255.0f);
+
+    bs::Color intensity  = bs::Color(intensityValue, intensityValue, intensityValue);
+    float intensityScale = fogScale * 0.5f;
+
+    // Calculate actual fog color
+    finalFogColor = (1.0f - intensityScale) * mMasterState.fogColor + intensityScale * intensity;
+  }
+
+  void SkyColoring::onWorldNameChanged(const bs::String& newWorldName)
+  {
+    // Must come before loading the config since fillSkyStates initializes everything with defaults
+    fillSkyStates();
+
+    // reloadAllSkyTextures(newWorldName); // TODO: Needs to be reimplemented, thus commented out
+  }
+
+  bool SkyColoring::isNightTime() const
+  {
+    return mMasterState.time >= TIME_KEY_1 && mMasterState.time <= TIME_KEY_7;
+  }
+
+  bs::Color SkyColoring::getPolyCloudsLayerColor()
+  {
+    bs::Color color;
+
+    if (isNightTime())
+    {
+      color = bs::Color::White;
+    }
+    else
+    {
+      color = mMasterState.domeColorUpper;
+    }
+
+    // At night, we want to keep the clouds white instead of getting a blueish tint
+    if (mMasterState.time >= TIME_KEY_3 && mMasterState.time <= TIME_KEY_5)
+    {
+      color = 0.5f * (color + bs::Color::White);
+    }
+
+    return color;
+  }
+}  // namespace REGoth

--- a/src/sky/SkyColoring.hpp
+++ b/src/sky/SkyColoring.hpp
@@ -1,0 +1,166 @@
+#pragma once
+
+#include <BsPrerequisites.h>
+#include <BsZenLib/ZenResources.hpp>
+#include <Image/BsColor.h>
+#include <Math/BsVector2.h>
+#include <RTTI/RTTIUtil.hpp>
+
+namespace REGoth
+{
+  /**
+   * Skystates, in order of appearance
+   */
+  enum class SkyPresetType : bs::UINT32
+  {
+    Day1 = 0,
+    Day2,
+    Evening,
+    Night0,
+    Night1,
+    Night2,
+    Dawn,
+    Day0,
+    NUM_PRESETS
+  };
+
+  class SkyConfig;
+
+  /**
+   * This class will calculate the ambient light color emitted by the sky.
+   *
+   * As in the real world, the color of the ambient light changes depending on the
+   * daytime in the original game. To archive this effect, the game uses a list of
+   * so called `SkyState`s, which describe the look of the sky at a single fixed point
+   * in time. During the day/night cycle, the game then interpolates between two of
+   * those `SkyState`s, the one closest *before* the current time, and the closest
+   * next one. The interpolated color is then applied as ambient lighting and fog
+   * color.
+   *
+   * Fog will also be calculated by this class, since it's parameters are embedded
+   * inside the `SkyState`s as well.
+   *
+   * Since sky rendering is a pretty complex topic in the original game, this class
+   * contains a lot of magic numbers of which we are not quite sure why many of them
+   * were chosen. Probably only because it looked good.
+   */
+  class SkyColoring
+  {
+  public:
+    struct SkyLayer
+    {
+      bs::String textureNameBase;
+
+      float textureAlpha;
+      float textureScale;
+      bs::Vector2 textureSpeed;
+    };
+
+    /**
+     * One skystate which can be interpolated into
+     */
+    struct SkyState
+    {
+      // Time when this state becomes active
+      // time in days since last 12:00
+      float time;
+
+      // Color values
+      bs::Color baseColor;
+      bs::Color fogColor;
+      bs::Color domeColorUpper;
+
+      // Base-fog distance modifier
+      float fogDistance;
+
+      // Whether the sun should be active. If false, the moon is.
+      bool isSunActive;
+
+      // Information about the cloud and sky layers
+      SkyLayer cloudsLayer;
+      SkyLayer skyLayer;
+    };
+
+    SkyColoring();
+    virtual ~SkyColoring();
+
+    /**
+     * Updates the sky and the colors.
+     *
+     * @param  dayRatio  Value in range 0..1 where 0 means start of day and 1 and of day.
+     *                   For example, if the clock reads 0:00, this would need to be 0.
+     *                   If the clock reads 23:59 this would ne to be close to 1.
+     */
+    void interpolate(float dayRatio);
+
+    /**
+     * Fills the sky states with their preset values
+     */
+    void fillSkyStates();
+
+    /**
+     * To be called when the name of the current level changed, so the sky can adapt to
+     * custom-textures the world may has.
+     *
+     * @param  newWorldName Name of the loaded Zen-File, e.g. `WORLD` for `WORLD.ZEN`
+     */
+    void onWorldNameChanged(const bs::String& newWorldName);
+
+    /**
+     * Outputs the two colors to lerp intensity values with to turn it into a sky-colored pixel
+     */
+    void getSkyColors(bs::Color& color0, bs::Color& color1);
+
+    /**
+     * Calculates the near- and farplanes for the fog
+     *
+     * @param[out]  distanceNear  Where the fog should start.
+     * @param[out]  distanceEnd   Where the fog should end.
+     * @param[out]  color         How the fog should be colored.
+     */
+    void calculateFogDistanceAndColor(float& nearFog, float& farFog, bs::Color& finalFogColor) const;
+
+    /**
+     * @return Whether it's currently nighttime
+     */
+    bool isNightTime() const;
+
+    /**
+     * @return Color of the coulds layer as poly (layer 1)
+     */
+    bs::Color getPolyCloudsLayerColor();
+
+  private:
+    /**
+     * Finds the two sky states we need to interpolate between for the current time.
+     * For example, if the current time is 0.28, this will find the sky states for
+     * time 0.25 and the one for 0.30.
+     *
+     * The current time is read from the master state.
+     *
+     * @param[out]  s0  Index of the state to interpolate from.
+     * @param[out]  s1  Index of the state to interpolate to.
+     */
+    void findTwoSkyStatesToInterpolateBetween(bs::UINT32& s0, bs::UINT32& s1) const;
+
+    /**
+     * Interpolates the two given sky states and stores the result into the master state.
+     */
+    void interpolateAndStoreIntoMasterState(const SkyState& s0, const SkyState& s1);
+
+    /**
+     * Initializes the given skystate to the given type
+     */
+    static void initSkyState(SkyPresetType type, SkyState& s);
+
+    /**
+     * Skystates we're interpolating
+     */
+    std::array<SkyState, (bs::UINT32)SkyPresetType::NUM_PRESETS> mSkyStates;
+
+    /**
+     * Interpolated skystate
+     */
+    SkyState mMasterState;
+  };
+}  // namespace REGoth


### PR DESCRIPTION
Ports some of the Sky-Logic from the old REGoth repository. This PR adds a component to the `GameWorld`, which calculates the sky color depending on the daytime using the Gothic 2 sky colors.

To test this, one can modify `GameClock` from this:

```cpp
constexpr float CLOCK_SPEED_FACTOR  = SECONDS_IN_A_DAY/6000;
``` 
to

```cpp
constexpr float CLOCK_SPEED_FACTOR  = SECONDS_IN_A_DAY/60;
``` 
for 60 second days.


[WIP]: Color is not applied to any meshes now, only the clear color is modified.
Using an indoor-world like `OLDMINE.ZEN` works for testing, but you need to peek through the wall with your camera to see the effect.

Also #35 should be merged first.