### PR TITLE
Give zCVobStartpoint's scene object a well defined name

### DIFF
--- a/src/components/GameWorld.cpp
+++ b/src/components/GameWorld.cpp
@@ -16,6 +16,8 @@
 
 namespace REGoth
 {
+  const char* const WORLD_STARTPOINT = "STARTPOINT";
+
   GameWorld::GameWorld(const bs::HSceneObject& parent, const bs::String& zenFile)
       : bs::Component(parent)
       , mZenFile(zenFile)

--- a/src/components/GameWorld.hpp
+++ b/src/components/GameWorld.hpp
@@ -20,6 +20,8 @@ namespace REGoth
   class GameWorld;
   using HGameWorld = bs::GameObjectHandle<GameWorld>;
 
+  extern const char* const WORLD_STARTPOINT;
+
   namespace Scripting
   {
     class ScriptVMForGameWorld;

--- a/src/main_WorldViewer.cpp
+++ b/src/main_WorldViewer.cpp
@@ -53,7 +53,7 @@ public:
     {
       world = GameWorld::importZEN(WORLD);
 
-      HCharacter hero = world->insertCharacter("PC_HERO", "START");
+      HCharacter hero = world->insertCharacter("PC_HERO", WORLD_STARTPOINT);
       hero->useAsHero();
       hero->SO()->addComponent<CharacterKeyboardInput>();
 

--- a/src/world/internals/ImportSingleVob.cpp
+++ b/src/world/internals/ImportSingleVob.cpp
@@ -184,6 +184,11 @@ namespace REGoth
     // Startpoint is found by name of the scene object
     bs::gDebug().logDebug("[ImportSingleVob] Found startpoint: " + so->getName());
 
+    // A startpoint has an arbitrary names, which makes it hard to find it at a later point.
+    // Thus, rename it to a known constant. As there should always only be one startpoint in
+    // a world, this should cause no conflicts.
+    so->setName(WORLD_STARTPOINT);
+
     return so;
   }
 


### PR DESCRIPTION
This implements a simple solution to #28.
I'm not sure if there's a better place for the WORLD_STARTPOINT constant, just let me know.